### PR TITLE
Add CI workflow to run tests on merge

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,26 @@
+name: Test on Merge
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  tests:
+    name: Run test suite
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v1
+
+      - name: Run tests
+        run: uv run --with dev pytest --cov=pycontextify


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that runs the test suite with coverage on pushes to main
- install uv and execute `uv run --with dev pytest --cov=pycontextify`

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df63ce9c0c83329e508bcbcfed0dda