### PR TITLE
Add manual PyPI deployment workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,59 @@
+name: Publish to PyPI
+
+on:
+  workflow_dispatch:
+    inputs:
+      repository:
+        description: "Target repository to upload the package"
+        required: true
+        default: pypi
+        type: choice
+        options:
+          - pypi
+          - testpypi
+      version:
+        description: "Version to publish (for traceability only)"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Show release target
+        run: |
+          echo "::notice::Preparing to publish version ${{ inputs.version }} to ${{ inputs.repository }}"
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install build dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install build twine
+
+      - name: Build distribution artifacts
+        run: python scripts/build_package.py
+
+      - name: Publish to TestPyPI
+        if: ${{ inputs.repository == 'testpypi' }}
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.TEST_PYPI_API_TOKEN }}
+        run: python -m twine upload --repository testpypi dist/*
+
+      - name: Publish to PyPI
+        if: ${{ inputs.repository == 'pypi' }}
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+        run: python -m twine upload dist/*

--- a/README.md
+++ b/README.md
@@ -25,6 +25,20 @@ uv sync
 uv run pycontextify --verbose
 ```
 
+### Run with `uvx`
+
+If you want to execute the published CLI without modifying your current
+environment, `uvx` can resolve `pycontextify` from PyPI and run its console
+entry point directly:
+
+```bash
+uvx pycontextify -- --help
+```
+
+The double dash (`--`) ensures any following arguments are forwarded to
+PyContextify itself. This requires a released version of the package to be
+available on PyPI, which the manual publishing workflow now provides.
+
 ## System Requirements
 
 - **Python**: Python 3.10 or newer for the MCP server core (full test suite currently targets Python 3.13+).【F:pyproject.toml†L1-L35】【F:tests/README.md†L57-L63】

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -13,6 +13,11 @@ This document captures the steps required to publish a new version of PyContexti
 3. **Verify dependencies**
    - Run `uv sync --extra dev` to install the `dev` extra (includes `build` and `twine`)
    - Review `pyproject.toml` for any dependency adjustments needed for the release
+4. **Sanity check CLI entry point**
+   - After building (or once the package is live on TestPyPI/PyPI), confirm the
+     console script is discoverable with `uvx pycontextify -- --help`
+   - This verifies the `pycontextify` entry point remains correctly exposed for
+     users invoking the tool via `uvx`
 
 ## Quality Gates
 


### PR DESCRIPTION
## Summary
- add a workflow_dispatch-driven GitHub Action to build and publish releases
- allow choosing between PyPI and TestPyPI using repository inputs
- document how to invoke the published CLI via `uvx` and add a release checklist step to verify the entry point

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e222dbbb6c83328d4f772fdf5a4509