### PR TITLE
Fix uv run command for dev dependencies

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,4 +29,4 @@ jobs:
         uses: astral-sh/setup-uv@v1
 
       - name: Run tests
-        run: uv run --with dev pytest --cov=pycontextify
+        run: uv run --extra dev --group dev pytest --cov=pycontextify

--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ Run tests:
 
 ```bash
 # Run all tests with coverage (requires the dev dependency group for pytest-cov)
-uv run --with dev pytest --cov=pycontextify
+uv run --extra dev --group dev pytest --cov=pycontextify
 
 # Run MCP-specific tests
 uv run python scripts/run_mcp_tests.py


### PR DESCRIPTION
## Summary
- update the test workflow to use uv's --extra/--group flags so development dependencies resolve correctly
- align the README instructions with the corrected uv invocation

## Testing
- not run (requires large downloads)


------
https://chatgpt.com/codex/tasks/task_e_68e28ecee86483328ae04b8c598ab795