### PR TITLE
Pin uv version supporting dependency groups in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,6 +27,8 @@ jobs:
 
       - name: Set up uv
         uses: astral-sh/setup-uv@v1
+        with:
+          version: "0.4.20"
 
       - name: Run tests
-        run: uv run --with dev pytest --cov=pycontextify
+        run: uv run --extra dev --group dev pytest --cov=pycontextify

--- a/README.md
+++ b/README.md
@@ -212,8 +212,8 @@ Full docs: See [WARP.md](./WARP.md) for development guidance and architecture de
 Run tests:
 
 ```bash
-# Run all tests with coverage (requires the dev dependency group for pytest-cov)
-uv run --with dev pytest --cov=pycontextify
+# Run all tests with coverage (requires uv >= 0.4.20 for dependency groups)
+uv run --extra dev --group dev pytest --cov=pycontextify
 
 # Run MCP-specific tests
 uv run python scripts/run_mcp_tests.py


### PR DESCRIPTION
## Summary
- update the test workflow to use uv's --extra/--group flags so development dependencies resolve correctly
- align the README instructions with the corrected uv invocation and note the minimum uv version needed
- pin the GitHub Actions uv installation to v0.4.20 so dependency groups are supported in CI

## Testing
- not run (requires large downloads)

------
https://chatgpt.com/codex/tasks/task_e_68e28ecee86483328ae04b8c598ab795