### PR TITLE
Refactor index manager into service-oriented architecture

### DIFF
--- a/pycontextify/indexer/manager.py
+++ b/pycontextify/indexer/manager.py
@@ -1,1628 +1,173 @@
-"""Central IndexManager for PyContextify.
+"""Central IndexManager orchestrating indexing services."""
 
-This module implements the main coordination system that orchestrates all
-components for indexing operations, persistence, and search functionality.
-"""
+from __future__ import annotations
 
-import hashlib
 import logging
-import os
-import shutil
-import tarfile
-import threading
-import time
-import zipfile
-from pathlib import Path
-from tempfile import TemporaryDirectory
-from typing import Any, Dict, List, Optional
-from urllib.parse import unquote, urlparse
-from urllib.request import url2pathname
+from typing import Any, Dict
 
-import psutil
-import requests
-
-from ..chunker import ChunkerFactory
 from ..orchestrator.config import Config
-from ..embedder import EmbedderFactory
-from .loaders import LoaderFactory
-from ..storage.metadata import MetadataStore, SourceType
-from ..search.models import (
-    SearchErrorCode,
-    SearchPerformanceLogger,
-    SearchResponse,
-    SearchResult,
-    create_search_performance_info,
-    create_search_provenance,
-    create_structured_metadata,
-    create_structured_scores,
-    enhance_search_results_with_ranking,
+from ..search.models import SearchResponse
+from ..storage.metadata import MetadataStore
+from .services import (
+    BootstrapService,
+    EmbeddingService,
+    IndexingService,
+    PersistenceService,
+    SearchService,
+    SystemStatusService,
 )
-from ..storage.vector import VectorStore
 
 logger = logging.getLogger(__name__)
 
 
 class IndexManager:
-    """Central manager for all indexing operations with auto-persistence."""
+    """High-level façade coordinating indexing, persistence and search."""
 
-    def __init__(self, config: Config):
-        """Initialize IndexManager with configuration.
-
-        Args:
-            config: Configuration object
-        """
+    def __init__(self, config: Config) -> None:
         self.config = config
-
-        # Initialize components
         self.metadata_store = MetadataStore()
-        self.embedder = None
-        self.vector_store = None
-        self.hybrid_search = None
-        # Store embedder configuration for lazy loading
-        self._embedder_config = None
-        self._embedder_initialized = False
-        self._bootstrap_thread: Optional[threading.Thread] = None
-        self._bootstrap_lock = threading.Lock()
-        self._load_lock = threading.Lock()
 
-        # Initialize performance logger
-        self.performance_logger = SearchPerformanceLogger()
-
-        # Initialize hybrid search (lightweight)
-        self._initialize_hybrid_search()
-
-        # Auto-load existing index if enabled
-        if self.config.auto_load:
-            self._auto_load()
-
-    def _ensure_embedder_loaded(self) -> None:
-        """Ensure embedder is loaded (lazy loading)."""
-        if self._embedder_initialized:
-            return
-
-        try:
-            embedding_config = self.config.get_embedding_config()
-            logger.info(
-                f"Lazy loading embedder: {embedding_config['provider']} with model {embedding_config['model']}"
-            )
-
-            self.embedder = EmbedderFactory.create_embedder(
-                provider=embedding_config["provider"],
-                model_name=embedding_config["model"],
-                **{
-                    k: v
-                    for k, v in embedding_config.items()
-                    if k not in ["provider", "model"]
-                },
-            )
-
-            # Mark as initialized before initializing vector store
-            self._embedder_initialized = True
-
-            # Initialize vector store now that we have embedder
-            self._initialize_vector_store()
-
-            logger.info(
-                f"Successfully loaded embedder: {self.embedder.get_provider_name()}"
-            )
-
-        except Exception as e:
-            logger.error(f"Failed to initialize embedder: {e}")
-            raise
-
-    def _initialize_vector_store(self) -> None:
-        """Initialize FAISS vector store (lazy)."""
-        # Only initialize if embedder is already loaded and vector store doesn't exist
-        if self._embedder_initialized and self.embedder and self.vector_store is None:
-            dimension = self.embedder.get_dimension()
-            self.vector_store = VectorStore(dimension, self.config)
-            logger.info(f"Initialized vector store with dimension {dimension}")
-
-    def _initialize_hybrid_search(self) -> None:
-        """Initialize hybrid search engine if enabled."""
-        if not self.config.use_hybrid_search:
-            logger.info("Hybrid search disabled by configuration")
-            return
-
-        try:
-            from ..search.hybrid import HybridSearchEngine
-
-            self.hybrid_search = HybridSearchEngine(
-                keyword_weight=self.config.keyword_weight
-            )
-            logger.info(
-                f"Initialized hybrid search with keyword weight: {self.config.keyword_weight}"
-            )
-        except ImportError as e:
-            logger.warning(f"Could not initialize hybrid search: {e}")
-            self.hybrid_search = None
-
-    def _generate_query_suggestions(
-        self, query: str, word_count: int, intent: str
-    ) -> List[str]:
-        """Generate intelligent query suggestions based on patterns and intent."""
-        suggestions = []
-
-        # Single word queries - suggest expansions
-        if word_count == 1 and len(query) > 3:
-            suggestions.extend(
-                [
-                    f"how to {query}",
-                    f"{query} example",
-                    f"{query} tutorial",
-                    f"{query} documentation",
-                ]
-            )
-
-        # Long queries - suggest simplification
-        elif word_count > 8:
-            key_words = [word for word in query.split() if len(word) > 3][:4]
-            suggestions.append(" ".join(key_words))
-
-        # Intent-based suggestions
-        if intent == "informational":
-            if "how" not in query.lower():
-                suggestions.append(f"how to {query}")
-            suggestions.append(f"{query} guide")
-
-        elif intent == "example_seeking":
-            if "example" not in query.lower():
-                suggestions.append(f"{query} example")
-            suggestions.append(f"{query} sample code")
-
-        elif intent == "comparative":
-            if "vs" not in query.lower() and "versus" not in query.lower():
-                words = query.split()
-                if len(words) >= 2:
-                    suggestions.append(f"{words[0]} vs {words[-1]}")
-
-        # Remove duplicates and limit
-        return list(dict.fromkeys(suggestions))[:5]
-
-    def _generate_expansion_terms(self, normalized_query: str) -> List[str]:
-        """Generate semantic expansion terms based on query content."""
-        expansion_terms = []
-
-        # Technical domains
-        tech_expansions = {
-            "code": ["implementation", "example", "tutorial", "function", "method"],
-            "function": ["method", "implementation", "code", "usage"],
-            "api": ["documentation", "endpoint", "reference", "integration"],
-            "database": ["query", "schema", "table", "sql"],
-            "web": ["html", "css", "javascript", "frontend", "backend"],
-            "security": [
-                "authentication",
-                "authorization",
-                "encryption",
-                "vulnerability",
-            ],
-            "performance": ["optimization", "speed", "efficiency", "benchmark"],
-        }
-
-        # Problem-solving terms
-        problem_expansions = {
-            "error": ["fix", "solution", "troubleshoot", "debug", "resolve"],
-            "bug": ["fix", "patch", "workaround", "issue", "problem"],
-            "issue": ["solution", "fix", "resolve", "troubleshoot"],
-            "problem": ["solution", "fix", "resolve", "answer"],
-        }
-
-        # Learning terms
-        learning_expansions = {
-            "tutorial": ["guide", "walkthrough", "example", "lesson"],
-            "guide": ["tutorial", "manual", "documentation", "howto"],
-            "example": ["sample", "demo", "illustration", "case study"],
-            "documentation": ["docs", "reference", "manual", "guide"],
-        }
-
-        # Combine all expansion dictionaries
-        all_expansions = {
-            **tech_expansions,
-            **problem_expansions,
-            **learning_expansions,
-        }
-
-        # Find matching terms and add expansions
-        for term, expansions in all_expansions.items():
-            if term in normalized_query:
-                expansion_terms.extend(expansions)
-
-        # Remove duplicates and terms already in query
-        query_words = set(normalized_query.split())
-        expansion_terms = [term for term in expansion_terms if term not in query_words]
-
-        return list(dict.fromkeys(expansion_terms))[:8]
-
-    def _suggest_search_strategies(
-        self, query: str, intent: str, complexity_score: float
-    ) -> List[Dict[str, str]]:
-        """Suggest alternative search strategies based on query analysis."""
-        strategies = []
-
-        # Strategy based on complexity
-        if complexity_score > 0.7:
-            strategies.append(
-                {
-                    "strategy": "simplify_query",
-                    "description": "Try breaking down your query into simpler terms",
-                    "rationale": "Complex queries may miss relevant results",
-                }
-            )
-
-        if complexity_score < 0.3 and len(query.split()) <= 2:
-            strategies.append(
-                {
-                    "strategy": "expand_query",
-                    "description": "Add more descriptive terms to narrow your search",
-                    "rationale": "Short queries may return too broad results",
-                }
-            )
-
-        # Intent-based strategies
-        if intent == "informational":
-            strategies.append(
-                {
-                    "strategy": "how_to_search",
-                    "description": "Try adding 'how to' or 'guide' to find tutorials",
-                    "rationale": "Informational queries benefit from instructional content",
-                }
-            )
-
-        elif intent == "example_seeking":
-            strategies.append(
-                {
-                    "strategy": "example_search",
-                    "description": "Search for 'sample', 'demo', or 'case study'",
-                    "rationale": "Example-focused searches find practical implementations",
-                }
-            )
-
-        # Domain-specific strategies
-        if any(
-            tech_term in query.lower()
-            for tech_term in ["code", "function", "api", "programming"]
-        ):
-            strategies.append(
-                {
-                    "strategy": "technical_search",
-                    "description": "Include programming language or framework names",
-                    "rationale": "Technical queries benefit from specific technology context",
-                }
-            )
-
-        return strategies[:3]  # Limit to top 3 strategies
-
-    def _auto_load(self) -> None:
-        """Automatically load existing index if available."""
-        try:
-            paths = self.config.get_index_paths()
-
-            essential_paths = {
-                key: value
-                for key, value in paths.items()
-                if key in ["metadata", "index"]
-            }
-            missing_paths = {
-                key: value
-                for key, value in essential_paths.items()
-                if not value.exists()
-            }
-
-            if missing_paths:
-                logger.info(
-                    "Detected missing index artifacts: %s",
-                    ", ".join(sorted(path.name for path in missing_paths.values())),
-                )
-                if self._restore_from_backups(missing_paths):
-                    missing_paths = {
-                        key: value
-                        for key, value in essential_paths.items()
-                        if not value.exists()
-                    }
-
-            if not missing_paths:
-                self._load_existing_index(paths)
-                return
-
-            logger.info("No existing index found, starting fresh")
-            self._schedule_bootstrap(paths)
-        except Exception as e:
-            logger.warning(f"Failed to load existing index: {e}")
-            import traceback
-
-            logger.debug(traceback.format_exc())
-
-    def _load_existing_index(self, paths: Dict[str, Path]) -> None:
-        """Load existing index artifacts into memory."""
-        with self._load_lock:
-            logger.info("Loading existing index...")
-
-            self.metadata_store.load_from_file(str(paths["metadata"]))
-
-            if self.metadata_store.get_stats().get("total_chunks", 0) > 0:
-                embedding_info = self.metadata_store.get_embedding_info()
-                if embedding_info and embedding_info.get("models"):
-                    first_model = embedding_info["models"][0]
-                    if ":" in first_model:
-                        stored_provider, stored_model = first_model.split(":", 1)
-                        self.config.embedding_provider = stored_provider
-                        self.config.embedding_model = stored_model
-                        logger.info(
-                            "Loading with stored embedding settings: %s:%s",
-                            stored_provider,
-                            stored_model,
-                        )
-
-                self._ensure_embedder_loaded()
-
-                if self.vector_store is not None:
-                    self.vector_store.load_from_file(str(paths["index"]))
-                    logger.info(
-                        f"Loaded {self.vector_store.get_total_vectors()} vectors"
-                    )
-                else:
-                    logger.error("Vector store not initialized, cannot load vectors")
-            else:
-                logger.info("No chunks in metadata, skipping vector loading")
-
-            logger.info("Successfully loaded existing index")
-
-    def _restore_from_backups(self, missing_paths: Dict[str, Path]) -> bool:
-        """Attempt to restore missing artifacts from VectorStore backups."""
-
-        restored_any = False
-        for path in missing_paths.values():
-            if VectorStore.restore_latest_backup(path):
-                restored_any = True
-
-        if restored_any:
-            logger.info("Restored one or more index artifacts from backups")
-
-        return restored_any
-
-    def _schedule_bootstrap(self, paths: Dict[str, Path]) -> None:
-        """Schedule asynchronous bootstrap of index artifacts when configured."""
-
-        sources = self.config.get_bootstrap_sources()
-        if not sources:
-            logger.info("Bootstrap archive URL not configured; skipping bootstrap")
-            return
-
-        with self._bootstrap_lock:
-            if self._bootstrap_thread and self._bootstrap_thread.is_alive():
-                logger.debug("Bootstrap worker already running; skipping reschedule")
-                return
-
-            logger.info("Scheduling bootstrap download for missing index artifacts")
-            self._bootstrap_thread = threading.Thread(
-                target=self._bootstrap_index_from_archive,
-                args=(paths, sources),
-                name="pycontextify-index-bootstrap",
-                daemon=True,
-            )
-            self._bootstrap_thread.start()
-
-    def _bootstrap_index_from_archive(
-        self, paths: Dict[str, Path], sources: Dict[str, str]
-    ) -> None:
-        """Download, verify, and extract bootstrap archive into place."""
-
-        archive_url = sources.get("archive")
-        checksum_url = sources.get("checksum")
-
-        if not archive_url or not checksum_url:
-            logger.warning("Bootstrap sources incomplete, skipping bootstrap")
-            return
-
-        try:
-            essential_paths = {
-                key: value
-                for key, value in paths.items()
-                if key in ["metadata", "index"]
-            }
-            missing_paths = {
-                key: value
-                for key, value in essential_paths.items()
-                if not value.exists()
-            }
-            if not missing_paths:
-                logger.info("Bootstrap skipped because index artifacts already exist")
-                return
-
-            if self._restore_from_backups(missing_paths):
-                missing_paths = {
-                    key: value
-                    for key, value in essential_paths.items()
-                    if not value.exists()
-                }
-                if not missing_paths:
-                    logger.info(
-                        "Bootstrap cancelled after restoring artifacts from backups"
-                    )
-                    self._load_existing_index(paths)
-                    return
-
-            with TemporaryDirectory(prefix="pycontextify-bootstrap-") as tmpdir:
-                temp_dir = Path(tmpdir)
-                archive_path = self._download_to_path(archive_url, temp_dir)
-                checksum_value = self._fetch_checksum(checksum_url)
-                self._verify_checksum(archive_path, checksum_value)
-
-                extract_dir = temp_dir / "extracted"
-                extract_dir.mkdir(parents=True, exist_ok=True)
-                self._extract_archive(archive_path, extract_dir)
-                self._move_bootstrap_artifacts(extract_dir, paths)
-
-            remaining_missing = {
-                key: value
-                for key, value in essential_paths.items()
-                if not value.exists()
-            }
-            if remaining_missing:
-                logger.warning(
-                    "Bootstrap archive did not provide all required artifacts: %s",
-                    ", ".join(sorted(path.name for path in remaining_missing.values())),
-                )
-                return
-
-            logger.info("Bootstrap archive applied successfully; loading index")
-            self._load_existing_index(paths)
-        except Exception as exc:
-            logger.warning(f"Failed to bootstrap index from {archive_url}: {exc}")
-
-    def _download_to_path(
-        self, url: str, destination_dir: Path, max_retries: int = 3
-    ) -> Path:
-        """Download or copy the given URL into destination_dir with retry logic.
-
-        Args:
-            url: URL to download from (http://, https://, or file://)
-            destination_dir: Directory to save the downloaded file
-            max_retries: Maximum number of retry attempts (default: 3)
-
-        Returns:
-            Path to the downloaded file
-
-        Raises:
-            FileNotFoundError: If file:// URL points to non-existent file
-            ValueError: If URL scheme is not supported
-            Exception: After max retries exhausted for transient errors
-        """
-        parsed = urlparse(url)
-        filename = Path(unquote(parsed.path or "")).name or "bootstrap_archive"
-        destination_dir.mkdir(parents=True, exist_ok=True)
-        target_path = destination_dir / filename
-
-        # Handle file:// URLs without retry (local filesystem)
-        if parsed.scheme == "file":
-            # Use url2pathname to handle Windows paths properly
-            # (e.g., file:///C:/path becomes C:\path on Windows)
-            local_path = url2pathname(parsed.path)
-            source_path = Path(local_path)
-            if not source_path.exists():
-                raise FileNotFoundError(
-                    f"Bootstrap archive file not found: {source_path}"
-                )
-            logger.info("Copying bootstrap archive from %s", source_path)
-            shutil.copy2(source_path, target_path)
-            return target_path
-
-        # Handle http:// and https:// URLs with retry logic
-        if parsed.scheme in ("http", "https"):
-            last_exception = None
-            for attempt in range(1, max_retries + 1):
-                try:
-                    if attempt > 1:
-                        # Exponential backoff: 1s, 2s, 4s, ...
-                        delay = 2 ** (attempt - 2)
-                        logger.info(
-                            f"Retrying download after {delay}s delay (attempt "
-                            f"{attempt}/{max_retries})"
-                        )
-                        time.sleep(delay)
-
-                    logger.info(
-                        f"Downloading bootstrap archive from {url} "
-                        f"(attempt {attempt}/{max_retries})"
-                    )
-                    response = requests.get(url, stream=True, timeout=30)
-                    response.raise_for_status()
-
-                    # Write to temporary file first, then rename atomically
-                    temp_path = target_path.with_suffix(".tmp")
-                    with temp_path.open("wb") as handle:
-                        for chunk in response.iter_content(chunk_size=1024 * 1024):
-                            if chunk:
-                                handle.write(chunk)
-
-                    # Atomic rename
-                    os.replace(temp_path, target_path)
-                    logger.info("Download completed successfully")
-                    return target_path
-
-                except requests.exceptions.Timeout as e:
-                    last_exception = e
-                    logger.warning(
-                        f"Download timeout on attempt {attempt}/{max_retries}: {e}"
-                    )
-                    # Retry on timeout
-                    continue
-
-                except requests.exceptions.ConnectionError as e:
-                    last_exception = e
-                    logger.warning(
-                        f"Connection error on attempt {attempt}/{max_retries}: {e}"
-                    )
-                    # Retry on connection errors
-                    continue
-
-                except requests.exceptions.HTTPError as e:
-                    # Check if error is retriable (408, 429, 5xx)
-                    if e.response is not None:
-                        status_code = e.response.status_code
-                        if status_code in (408, 429) or status_code >= 500:
-                            last_exception = e
-                            logger.warning(
-                                f"Retriable HTTP error {status_code} on attempt "
-                                f"{attempt}/{max_retries}: {e}"
-                            )
-                            continue  # Retry
-                        else:
-                            # Non-retriable 4xx error
-                            logger.error(f"Non-retriable HTTP error {status_code}: {e}")
-                            raise
-                    else:
-                        # No response, treat as retriable
-                        last_exception = e
-                        logger.warning(
-                            f"HTTP error on attempt {attempt}/{max_retries}: {e}"
-                        )
-                        continue
-
-                except Exception as e:
-                    # Unexpected errors - log and re-raise immediately
-                    logger.error(
-                        f"Unexpected error during download (attempt "
-                        f"{attempt}/{max_retries}): {e}"
-                    )
-                    raise
-
-            # All retries exhausted
-            error_msg = (
-                f"Failed to download {url} after {max_retries} attempts. "
-                f"Last error: {last_exception}"
-            )
-            logger.error(error_msg)
-            raise Exception(error_msg)
-
-        raise ValueError(f"Unsupported bootstrap scheme: {parsed.scheme}")
-
-    def _fetch_checksum(self, url: str, max_retries: int = 3) -> str:
-        """Retrieve checksum text from the provided URL with retry logic.
-
-        Args:
-            url: URL to fetch checksum from (http://, https://, or file://)
-            max_retries: Maximum number of retry attempts (default: 3)
-
-        Returns:
-            The SHA256 checksum as a hex string
-
-        Raises:
-            FileNotFoundError: If file:// URL points to non-existent file
-            ValueError: If checksum file is empty or malformed
-            Exception: After max retries exhausted for transient errors
-        """
-        parsed = urlparse(url)
-
-        # Handle file:// URLs
-        if parsed.scheme == "file":
-            # Use url2pathname to handle Windows paths properly
-            local_path = url2pathname(parsed.path)
-            checksum_path = Path(local_path)
-            if not checksum_path.exists():
-                raise FileNotFoundError(
-                    f"Bootstrap checksum file not found: {checksum_path}"
-                )
-            content = checksum_path.read_text(encoding="utf-8")
-        # Handle http:// and https:// URLs with retry
-        elif parsed.scheme in ("http", "https"):
-            last_exception = None
-            for attempt in range(1, max_retries + 1):
-                try:
-                    if attempt > 1:
-                        delay = 2 ** (attempt - 2)
-                        logger.info(
-                            f"Retrying checksum fetch after {delay}s "
-                            f"(attempt {attempt}/{max_retries})"
-                        )
-                        time.sleep(delay)
-
-                    logger.debug(f"Fetching checksum from {url}")
-                    response = requests.get(url, timeout=30)
-                    response.raise_for_status()
-                    content = response.text
-                    break
-
-                except (
-                    requests.exceptions.Timeout,
-                    requests.exceptions.ConnectionError,
-                ) as e:
-                    last_exception = e
-                    logger.warning(
-                        f"Error fetching checksum on attempt "
-                        f"{attempt}/{max_retries}: {e}"
-                    )
-                    if attempt == max_retries:
-                        raise Exception(
-                            f"Failed to fetch checksum after {max_retries} attempts. "
-                            f"Last error: {e}"
-                        )
-                    continue
-
-                except requests.exceptions.HTTPError as e:
-                    if e.response is not None:
-                        status_code = e.response.status_code
-                        if status_code in (408, 429) or status_code >= 500:
-                            last_exception = e
-                            logger.warning(
-                                f"Retriable HTTP error {status_code} "
-                                f"(attempt {attempt}/{max_retries})"
-                            )
-                            if attempt == max_retries:
-                                raise Exception(
-                                    f"Failed to fetch checksum after "
-                                    f"{max_retries} attempts"
-                                )
-                            continue
-                        else:
-                            logger.error(f"Non-retriable HTTP error {status_code}")
-                            raise
-                    raise
-        else:
-            raise ValueError(f"Unsupported checksum URL scheme: {parsed.scheme}")
-
-        # Parse checksum from content
-        if not content.strip():
-            raise ValueError("Bootstrap checksum file is empty")
-
-        # Support two formats:
-        # 1. "<hex_digest>" (just the hash)
-        # 2. "<hex_digest>  <filename>" (hash with filename)
-        parts = content.strip().split()
-        if not parts:
-            raise ValueError("Bootstrap checksum file is empty")
-
-        checksum = parts[0].lower()
-
-        # Validate it's a valid hex string
-        if len(checksum) != 64 or not all(c in "0123456789abcdef" for c in checksum):
-            raise ValueError(
-                f"Invalid SHA256 checksum format: {checksum[:20]}... "
-                "(expected 64 hex characters)"
-            )
-
-        logger.info(f"Fetched checksum: {checksum[:16]}...")
-        return checksum
-
-    def _verify_checksum(self, archive_path: Path, expected_checksum: str) -> None:
-        """Verify archive SHA256 checksum."""
-
-        digest = hashlib.sha256()
-        with archive_path.open("rb") as handle:
-            for chunk in iter(lambda: handle.read(1024 * 1024), b""):
-                digest.update(chunk)
-
-        actual_checksum = digest.hexdigest()
-        if actual_checksum.lower() != expected_checksum.lower():
-            raise ValueError(
-                "Bootstrap archive checksum mismatch: "
-                f"expected {expected_checksum}, got {actual_checksum}"
-            )
-
-    def _extract_archive(self, archive_path: Path, destination: Path) -> None:
-        """Extract supported archive formats into destination directory."""
-
-        lower_name = archive_path.name.lower()
-        if lower_name.endswith(".zip"):
-            with zipfile.ZipFile(archive_path) as zip_ref:
-                zip_ref.extractall(destination)
-            return
-
-        if lower_name.endswith(".tar.gz") or lower_name.endswith(".tgz"):
-            with tarfile.open(archive_path, "r:gz") as tar_ref:
-                tar_ref.extractall(destination)
-            return
-
-        raise ValueError(f"Unsupported bootstrap archive format: {archive_path}")
-
-    def _move_bootstrap_artifacts(
-        self, extract_dir: Path, paths: Dict[str, Path]
-    ) -> None:
-        """Move extracted files into their final locations if missing."""
-
-        for key in ["metadata", "index"]:
-            destination = paths[key]
-            if destination.exists():
-                continue
-
-            matches = list(extract_dir.rglob(destination.name))
-            if not matches:
-                logger.warning(
-                    "Bootstrap archive missing expected %s file %s",
-                    key,
-                    destination.name,
-                )
-                continue
-
-            source_path = matches[0]
-            destination.parent.mkdir(parents=True, exist_ok=True)
-            os.replace(source_path, destination)
-            logger.info("Bootstrapped %s", destination.name)
-
-    def _validate_embedding_compatibility(self) -> bool:
-        """Validate that existing index is compatible with current embedding settings."""
-        if self.metadata_store.get_stats()["total_chunks"] == 0:
-            return True
-
-        # Need embedder to validate compatibility
-        self._ensure_embedder_loaded()
-        return self.metadata_store.validate_embedding_compatibility(
-            self.embedder.get_provider_name(), self.embedder.get_model_name()
+        self._embedding_service = EmbeddingService(config)
+        self._persistence_service = PersistenceService(config, self._embedding_service)
+        self._search_service = SearchService(config, self.metadata_store, self._embedding_service)
+        self._indexing_service = IndexingService(
+            config, self.metadata_store, self._embedding_service
+        )
+        self._bootstrap_service = BootstrapService(
+            config, self.metadata_store, self._embedding_service
+        )
+        self._system_status_service = SystemStatusService(
+            config,
+            self.metadata_store,
+            self._embedding_service,
+            self._search_service,
         )
 
-    def _auto_save(self) -> None:
-        """Automatically save all components if auto-persist is enabled."""
-        if not self.config.auto_persist:
-            return
+        self.performance_logger = self._search_service.performance_logger
 
-        try:
-            self.config.ensure_index_directory()
-            paths = self.config.get_index_paths()
+        if self.config.auto_load:
+            self._bootstrap_service.auto_load()
 
-            # Save vector store
-            self.vector_store.save_to_file(str(paths["index"]))
+    # ------------------------------------------------------------------
+    # Properties exposing underlying services for backwards compatibility
+    # ------------------------------------------------------------------
+    @property
+    def embedder(self):
+        """Expose the lazily loaded embedder instance."""
+        return self._embedding_service.embedder
 
-            # Save metadata
-            self.metadata_store.save_to_file(
-                str(paths["metadata"]), self.config.compress_metadata
-            )
+    @property
+    def vector_store(self):
+        """Expose the managed vector store."""
+        return self._embedding_service.vector_store
 
-            logger.info("Auto-saved index to disk")
-        except Exception as e:
-            logger.error(f"Failed to auto-save index: {e}")
-            # Don't raise - indexing should continue even if save fails
+    @property
+    def hybrid_search(self):
+        """Expose the hybrid search engine when available."""
+        return self._search_service.get_hybrid_engine()
+
+    # ------------------------------------------------------------------
+    # Delegated behaviour
+    # ------------------------------------------------------------------
+    def _ensure_embedder_loaded(self) -> None:
+        """Compatibility helper for scripts invoking the old private API."""
+        self._embedding_service.ensure_loaded()
 
     def index_codebase(self, path: str) -> Dict[str, Any]:
-        """Index a codebase directory.
-
-        Args:
-            path: Path to codebase directory
-
-        Returns:
-            Statistics about the indexing operation
-        """
-        logger.info(f"Starting codebase indexing: {path}")
-
-        try:
-            # Load content
-            loader = LoaderFactory.get_loader(
-                SourceType.CODE, max_file_size_mb=self.config.max_file_size_mb
-            )
-            files = loader.load(path)
-
-            if not files:
-                return {"error": "No files found to index"}
-
-            # Process files
-            chunks_added = 0
-            for file_path, content in files:
-                chunks_added += self._process_content(
-                    content, file_path, SourceType.CODE
-                )
-
-            # Auto-save after successful indexing
-            self._auto_save()
-
-            # Ensure embedder loaded before accessing provider/model info
-            self._ensure_embedder_loaded()
-            stats = {
-                "files_processed": len(files),
-                "chunks_added": chunks_added,
-                "source_type": "code",
-                "embedding_provider": self.embedder.get_provider_name(),
-                "embedding_model": self.embedder.get_model_name(),
-            }
-
-            logger.info(f"Completed codebase indexing: {stats}")
+        """Index a codebase directory."""
+        stats = self._indexing_service.index_codebase(path)
+        if "error" in stats:
             return stats
-
-        except Exception as e:
-            error_msg = f"Failed to index codebase {path}: {str(e)}"
-            logger.error(error_msg)
-            return {"error": error_msg}
+        self._persistence_service.auto_save(self.metadata_store)
+        return self._augment_with_embedding_info(stats)
 
     def index_document(self, path: str) -> Dict[str, Any]:
-        """Index a single document.
-
-        Args:
-            path: Path to document file
-
-        Returns:
-            Statistics about the indexing operation
-        """
-        logger.info(f"Starting document indexing: {path}")
-
-        try:
-            # Load content with PDF engine configuration
-            loader = LoaderFactory.get_loader(
-                SourceType.DOCUMENT, pdf_engine=self.config.pdf_engine
-            )
-            files = loader.load(path)
-
-            if not files:
-                return {"error": "Could not load document"}
-
-            # Process document
-            file_path, content = files[0]
-            chunks_added = self._process_content(
-                content, file_path, SourceType.DOCUMENT
-            )
-
-            # Auto-save after successful indexing
-            self._auto_save()
-
-            # Ensure embedder loaded before accessing provider/model info
-            self._ensure_embedder_loaded()
-            stats = {
-                "file_processed": file_path,
-                "chunks_added": chunks_added,
-                "source_type": "document",
-                "embedding_provider": self.embedder.get_provider_name(),
-                "embedding_model": self.embedder.get_model_name(),
-            }
-
-            logger.info(f"Completed document indexing: {stats}")
+        """Index a single document."""
+        stats = self._indexing_service.index_document(path)
+        if "error" in stats:
             return stats
-
-        except Exception as e:
-            error_msg = f"Failed to index document {path}: {str(e)}"
-            logger.error(error_msg)
-            return {"error": error_msg}
+        self._persistence_service.auto_save(self.metadata_store)
+        return self._augment_with_embedding_info(stats)
 
     def index_webpage(
-        self,
-        url: str,
-        recursive: bool = False,
-        max_depth: int = 1,
+        self, url: str, recursive: bool = False, max_depth: int = 1
     ) -> Dict[str, Any]:
-        """Index web content.
-
-        Args:
-            url: URL to index
-            recursive: Whether to follow links
-            max_depth: Maximum crawl depth. 0 = unlimited, 1 = starting URL +
-                     direct children, 2 = includes grandchildren, etc.
-
-        Returns:
-            Statistics about the indexing operation
-        """
-        logger.info(
-            f"Starting webpage indexing: {url} "
-            f"(recursive={recursive}, max_depth={max_depth})"
-        )
-
-        try:
-            # Load content
-            loader = LoaderFactory.get_loader(
-                SourceType.WEBPAGE,
-                delay_seconds=self.config.crawl_delay_seconds,
-            )
-            pages = loader.load(url, recursive=recursive, max_depth=max_depth)
-
-            if not pages:
-                return {"error": "Could not load any web pages"}
-
-            # Process pages
-            chunks_added = 0
-            for page_url, content in pages:
-                chunks_added += self._process_content(
-                    content, page_url, SourceType.WEBPAGE
-                )
-
-            # Auto-save after successful indexing
-            self._auto_save()
-
-            # Ensure embedder loaded before accessing provider/model info
-            self._ensure_embedder_loaded()
-            stats = {
-                "pages_processed": len(pages),
-                "chunks_added": chunks_added,
-                "source_type": "webpage",
-                "recursive": recursive,
-                "max_depth": max_depth,
-                "embedding_provider": self.embedder.get_provider_name(),
-                "embedding_model": self.embedder.get_model_name(),
-            }
-
-            logger.info(f"Completed webpage indexing: {stats}")
+        """Index web content."""
+        stats = self._indexing_service.index_webpage(url, recursive, max_depth)
+        if "error" in stats:
             return stats
-
-        except Exception as e:
-            error_msg = f"Failed to index webpage {url}: {str(e)}"
-            logger.error(error_msg)
-            return {"error": error_msg}
-
-    def _process_content(
-        self, content: str, source_path: str, source_type: SourceType
-    ) -> int:
-        """Process content into chunks and add to index.
-
-        Args:
-            content: Text content to process
-            source_path: Source path or URL
-            source_type: Type of content
-
-        Returns:
-            Number of chunks added
-        """
-        # CHECK FOR EXISTING CONTENT AND REMOVE (RE-INDEXING LOGIC)
-        existing_chunks = self.metadata_store.get_chunks_by_source_path(source_path)
-        chunks_removed = 0
-
-        if existing_chunks:
-            logger.info(
-                f"Found {len(existing_chunks)} existing chunks for {source_path}, removing for re-indexing"
-            )
-
-            # Remove from vector store
-            if self.vector_store is not None:
-                faiss_ids_to_remove = []
-                for chunk in existing_chunks:
-                    faiss_id = self.metadata_store.get_faiss_id(chunk.chunk_id)
-                    if faiss_id is not None:
-                        faiss_ids_to_remove.append(faiss_id)
-
-                if faiss_ids_to_remove:
-                    self.vector_store.remove_vectors(faiss_ids_to_remove)
-
-            # Remove from metadata store
-            for chunk in existing_chunks:
-                faiss_id = self.metadata_store.get_faiss_id(chunk.chunk_id)
-                if faiss_id is not None:
-                    self.metadata_store.remove_chunk(faiss_id)
-
-            chunks_removed = len(existing_chunks)
-            logger.info(f"Removed {chunks_removed} existing chunks for re-indexing")
-
-        # Get appropriate chunker
-        chunker = ChunkerFactory.get_chunker(source_type, self.config)
-
-        # Ensure embedder is loaded before chunking (we pass provider/model info)
-        self._ensure_embedder_loaded()
-
-        # Chunk content
-        chunks = chunker.chunk_text(
-            content,
-            source_path,
-            self.embedder.get_provider_name(),
-            self.embedder.get_model_name(),
-        )
-
-        if not chunks:
-            return 0
-
-        # Generate embeddings
-        texts = [chunk.chunk_text for chunk in chunks]
-        self._ensure_embedder_loaded()
-        embeddings = self.embedder.embed_texts(texts)
-
-        # Add to vector store
-        if self.vector_store is None:
-            self._initialize_vector_store()
-        faiss_ids = self.vector_store.add_vectors(embeddings)
-
-        # Add metadata
-        for chunk, faiss_id in zip(chunks, faiss_ids):
-            self.metadata_store.add_chunk(chunk)
-
-        return len(chunks)
-
-    def _get_search_config(self) -> Dict[str, Any]:
-        """Get current search configuration for response metadata."""
-        return {
-            "hybrid_search": self.config.use_hybrid_search,
-            "embedding_provider": self.config.embedding_provider,
-            "embedding_model": self.config.embedding_model,
-            "keyword_weight": getattr(self.config, "keyword_weight", 0.3),
-        }
-
-    def _create_source_info_from_chunk(self, chunk) -> Dict[str, Any]:
-        """Create source info from chunk metadata.
-
-        Args:
-            chunk: ChunkMetadata object
-
-        Returns:
-            Dictionary with enhanced source metadata
-        """
-        from pathlib import Path
-
-        from .pdf_loader import PDFLoader
-
-        # Get source_path safely, handling both real objects and mocks
-        source_path = getattr(chunk, "source_path", "/unknown")
-        source_type_val = getattr(chunk, "source_type", None)
-
-        # Handle source_type.value safely (could be enum or string)
-        if hasattr(source_type_val, "value"):
-            source_type_str = source_type_val.value
-        else:
-            source_type_str = str(source_type_val) if source_type_val else "unknown"
-
-        source_info = {
-            "file_path": str(source_path) if source_path else "/unknown",
-            "source_type": source_type_str,
-        }
-
-        # Only proceed with file operations if we have a real string path
-        if isinstance(source_path, str) and source_path != "/unknown":
-            # Basic file information
-            try:
-                file_path = Path(source_path)
-                if file_path.exists() and file_path.is_file():
-                    stat = file_path.stat()
-                    source_info.update(
-                        {
-                            "filename": file_path.name,
-                            "file_extension": file_path.suffix.lower(),
-                            "file_size_bytes": stat.st_size,
-                            "file_size_mb": round(stat.st_size / (1024 * 1024), 2),
-                            "created_at": stat.st_ctime,
-                            "modified_at": stat.st_mtime,
-                        }
-                    )
-                else:
-                    # File doesn't exist, but we can still extract basic info
-                    source_info["filename"] = file_path.name
-                    source_info["file_extension"] = file_path.suffix.lower()
-            except (OSError, ValueError, TypeError) as e:
-                # Handle URLs or invalid paths gracefully
-                logger.debug(f"Could not extract file metadata: {e}")
-                try:
-                    source_info["filename"] = Path(source_path).name
-                    if source_path.startswith(("http://", "https://")):
-                        source_info["source_type"] = "webpage"
-                except Exception:
-                    source_info["filename"] = "unknown"
-
-            # PDF-specific metadata extraction
-            if source_type_str == "document" and source_path.lower().endswith(".pdf"):
-                try:
-                    pdf_loader = PDFLoader()
-                    pdf_metadata = pdf_loader.get_pdf_info(source_path)
-                    source_info.update(pdf_metadata)
-                except Exception as e:
-                    logger.debug(f"Could not extract PDF metadata: {e}")
-
-        # Page and section context from chunk text (safe to do even with mocks)
-        chunk_text = getattr(chunk, "chunk_text", "")
-        if chunk_text and isinstance(chunk_text, str):
-            try:
-                pdf_loader = PDFLoader()
-                page_info = pdf_loader.extract_page_context(chunk_text)
-                if page_info:
-                    source_info.update(page_info)
-            except Exception as e:
-                logger.debug(f"Could not extract page context: {e}")
-
-        # Add chunk-specific metadata
-        if hasattr(chunk, "parent_section"):
-            parent_section = getattr(chunk, "parent_section", None)
-            if parent_section:
-                source_info["section_title"] = str(parent_section)
-
-        # Add additional metadata from chunk
-        if hasattr(chunk, "metadata"):
-            metadata = getattr(chunk, "metadata", None)
-            if metadata and hasattr(metadata, "items"):
-                try:
-                    for key, value in metadata.items():
-                        if key not in source_info and value is not None:
-                            source_info[key] = value
-                except Exception as e:
-                    logger.debug(f"Could not extract chunk metadata: {e}")
-
-        return source_info
-
-    def _ensure_hybrid_search_index(self) -> None:
-        """Ensure hybrid search index is built from current chunks."""
-        if not self.hybrid_search:
-            return
-
-        # Check if index needs to be built/updated
-        current_chunk_count = self.metadata_store.get_stats()["total_chunks"]
-        hybrid_stats = self.hybrid_search.get_stats()
-
-        if hybrid_stats["indexed_documents"] != current_chunk_count:
-            logger.info("Building hybrid search index...")
-
-            # Get all chunks
-            all_chunks = self.metadata_store.get_all_chunks()
-
-            if all_chunks:
-                chunk_ids = [chunk.chunk_id for chunk in all_chunks]
-                texts = [chunk.chunk_text for chunk in all_chunks]
-
-                # Build keyword search index
-                self.hybrid_search.add_documents(chunk_ids, texts)
-                logger.info(f"Built hybrid search index with {len(texts)} documents")
+        self._persistence_service.auto_save(self.metadata_store)
+        return self._augment_with_embedding_info(stats)
 
     def search(
         self, query: str, top_k: int = 5, display_format: str = "readable"
     ) -> SearchResponse:
-        """Perform semantic search with optional hybrid enhancement.
-
-        Args:
-            query: Search query text
-            top_k: Number of results to return
-            display_format: Output format ('readable', 'structured', 'summary')
-
-        Returns:
-            SearchResponse with results and metadata
-        """
-        return self._simple_search(query, top_k, display_format)
-
-    def _simple_search(
-        self, query: str, top_k: int = 5, display_format: str = "readable"
-    ) -> SearchResponse:
-        """Simplified search implementation with optional hybrid enhancement."""
-        import time
-
-        start_time = time.time()
-
-        try:
-            # Check if we have any indexed content
-            if self.vector_store is None or self.vector_store.is_empty():
-                return SearchResponse.create_error(
-                    query=query,
-                    error="No indexed content available. Please index some documents, code, or webpages first.",
-                    error_code=SearchErrorCode.NO_CONTENT.value,
-                    search_config=self._get_search_config(),
-                    recovery_suggestions=[
-                        "Use index_document(), index_codebase(), or index_webpage() to add content",
-                        "Check if auto_load is enabled and index files exist",
-                        "Verify the vector store was initialized properly",
-                    ],
-                )
-
-            # Ensure embedder is loaded
-            self._ensure_embedder_loaded()
-
-            # Generate query embedding
-            query_embedding = self.embedder.embed_single(query)
-
-            # Perform vector search
-            distances, indices = self.vector_store.search(
-                query_embedding, top_k * 2
-            )  # Get more for hybrid filtering
-
-            # Create initial results
-            search_results = self._create_vector_search_results(distances, indices)
-
-            # Apply hybrid search enhancement if enabled
-            if self.config.use_hybrid_search and self.hybrid_search:
-                try:
-                    self._ensure_hybrid_search_index()
-                    hybrid_results = self.hybrid_search.search(query, top_k * 2)
-
-                    # Combine semantic and keyword results
-                    combined_results = self._combine_hybrid_results(
-                        search_results, hybrid_results
-                    )
-                    search_results = combined_results[:top_k]
-                except Exception as e:
-                    logger.warning(f"Hybrid search failed, using vector-only: {e}")
-                    search_results = search_results[:top_k]
-            else:
-                search_results = search_results[:top_k]
-
-            # Enhance results with ranking information
-            enhanced_results = enhance_search_results_with_ranking(
-                results=search_results,
-                query=query,
-                include_explanations=True,
-                include_confidence=True,
-            )
-
-            # Create performance information
-            performance = create_search_performance_info(
-                start_time=start_time,
-                search_mode="hybrid" if self.config.use_hybrid_search else "vector",
-                total_candidates=len(search_results),
-            )
-
-            # Create successful response
-            response = SearchResponse.create_success(
-                query=query,
-                results=enhanced_results,
-                search_config=self._get_search_config(),
-                performance=performance,
-            )
-
-            # Set display format and generate formatted output
-            response.display_format = display_format
-            if display_format != "structured":
-                response.formatted_output = response.format_for_display(display_format)
-
-            # Log performance
-            self.performance_logger.log_search_performance(response)
-
-            return response
-
-        except Exception as e:
-            logger.error(f"Search failed: {e}")
-
-            error_response = SearchResponse.create_error(
-                query=query,
-                error=f"Search operation failed: {str(e)}",
-                error_code=SearchErrorCode.SEARCH_ERROR.value,
-                search_config=self._get_search_config(),
-                recovery_suggestions=[
-                    "Check if the index is properly loaded",
-                    "Verify the embedder is available and functional",
-                    "Try a simpler query if the current one is complex",
-                ],
-            )
-
-            return error_response
-
-    def _create_vector_search_results(self, distances, indices):
-        """Convert vector search results to SearchResult objects."""
-        results = []
-        for i, (distance, idx) in enumerate(zip(distances, indices)):
-            if idx >= 0:  # Valid index
-                chunk = self.metadata_store.get_chunk(idx)
-                if chunk:
-                    source_info = self._create_source_info_from_chunk(chunk)
-
-                    # Convert distance to similarity score (cosine distance -> similarity)
-                    relevance_score = max(0.0, 1.0 - distance)
-
-                    result = SearchResult(
-                        chunk_id=chunk.chunk_id,
-                        source_path=chunk.source_path,
-                        source_type=chunk.source_type.value,
-                        text=chunk.chunk_text,
-                        relevance_score=relevance_score,
-                        scores=create_structured_scores(
-                            vector_score=relevance_score,
-                            original_score=relevance_score,
-                        ),
-                        metadata=(
-                            create_structured_metadata(**chunk.metadata)
-                            if chunk.metadata
-                            else None
-                        ),
-                        provenance=create_search_provenance(
-                            search_features=["vector_search"],
-                            search_stage="vector_only",
-                        ),
-                        source_info=source_info,
-                    )
-                    results.append(result)
-        return results
-
-    def _combine_hybrid_results(self, vector_results, hybrid_results):
-        """Combine vector and hybrid search results with simple scoring."""
-        # Create a dictionary to track chunks by ID
-        combined_chunks = {}
-
-        # Add vector results
-        for result in vector_results:
-            combined_chunks[result.chunk_id] = {
-                "result": result,
-                "vector_score": result.relevance_score,
-                "keyword_score": 0.0,
-                "combined_score": result.relevance_score
-                * 0.7,  # Give vector search 70% weight
-            }
-
-        # Add/enhance with hybrid results
-        for hybrid_result in hybrid_results:
-            chunk_id = hybrid_result.get("chunk_id")
-            keyword_score = hybrid_result.get("score", 0.0)
-
-            if chunk_id in combined_chunks:
-                # Update existing result with hybrid score
-                combined_chunks[chunk_id]["keyword_score"] = keyword_score
-                combined_chunks[chunk_id]["combined_score"] = (
-                    combined_chunks[chunk_id]["vector_score"] * 0.7
-                    + keyword_score * 0.3
-                )
-            else:
-                # Create new result from hybrid search
-                chunk = self.metadata_store.get_chunk_by_chunk_id(chunk_id)
-                if chunk:
-                    source_info = self._create_source_info_from_chunk(chunk)
-
-                    result = SearchResult(
-                        chunk_id=chunk.chunk_id,
-                        source_path=chunk.source_path,
-                        source_type=chunk.source_type.value,
-                        text=chunk.chunk_text,
-                        relevance_score=keyword_score,
-                        scores=create_structured_scores(
-                            keyword_score=keyword_score,
-                            combined_score=keyword_score
-                            * 0.3,  # Pure keyword gets 30% weight
-                        ),
-                        metadata=(
-                            create_structured_metadata(**chunk.metadata)
-                            if chunk.metadata
-                            else None
-                        ),
-                        provenance=create_search_provenance(
-                            search_features=["hybrid_search"],
-                            search_stage="hybrid_only",
-                        ),
-                        source_info=source_info,
-                    )
-
-                    combined_chunks[chunk_id] = {
-                        "result": result,
-                        "vector_score": 0.0,
-                        "keyword_score": keyword_score,
-                        "combined_score": keyword_score * 0.3,
-                    }
-
-        # Sort by combined score and return results
-        sorted_items = sorted(
-            combined_chunks.values(), key=lambda x: x["combined_score"], reverse=True
-        )
-
-        # Update scores in results and return
-        final_results = []
-        for item in sorted_items:
-            result = item["result"]
-            result.relevance_score = item["combined_score"]
-
-            # Update scores with combined information
-            result.scores = create_structured_scores(
-                vector_score=item["vector_score"],
-                keyword_score=item["keyword_score"],
-                combined_score=item["combined_score"],
-                original_score=(
-                    result.scores.original_score
-                    if result.scores
-                    else item["combined_score"]
-                ),
-            )
-
-            final_results.append(result)
-
-        return final_results
+        """Perform semantic search with optional hybrid enhancement."""
+        return self._search_service.search(query, top_k, display_format)
 
     def get_performance_summary(self) -> Dict[str, Any]:
-        """Get search performance statistics summary.
-
-        Returns:
-            Dictionary with performance metrics and statistics
-        """
-        return self.performance_logger.get_performance_summary()
+        """Get search performance statistics summary."""
+        return self._search_service.get_performance_summary()
 
     def get_status(self) -> Dict[str, Any]:
-        """Get comprehensive system status.
-
-        Returns:
-            System status and statistics
-        """
-        try:
-            # Basic stats
-            metadata_stats = self.metadata_store.get_stats()
-            relationship_stats = {}  # Removed relationship store
-            vector_stats = (
-                self.vector_store.get_index_info()
-                if self.vector_store
-                else {"total_vectors": 0, "dimension": None}
-            )
-
-            # Create unified index stats
-            index_stats = {
-                "total_chunks": metadata_stats.get("total_chunks", 0),
-                "total_documents": len(
-                    set(
-                        chunk.source_path
-                        for chunk in self.metadata_store.get_all_chunks()
-                    )
-                ),
-                "total_vectors": vector_stats.get("total_vectors", 0),
-                "source_types": metadata_stats.get("source_types", {}),
-            }
-
-            # Memory usage
-            process = psutil.Process()
-            memory_mb = process.memory_info().rss / (1024 * 1024)
-
-            # Embedding info (handle lazy state)
-            if not self._embedder_initialized or self.embedder is None:
-                embedding_info = {
-                    "provider": self.config.embedding_provider,
-                    "model": self.config.embedding_model,
-                    "dimension": None,
-                    "is_available": False,
-                }
-            else:
-                embedding_info = {
-                    "provider": self.embedder.get_provider_name(),
-                    "model": self.embedder.get_model_name(),
-                    "dimension": self.embedder.get_dimension(),
-                    "is_available": self.embedder.is_available(),
-                }
-
-            # Persistence info
-            paths = self.config.get_index_paths()
-            essential_paths = {
-                k: v for k, v in paths.items() if k in ["metadata", "index"]
-            }
-            persistence_info = {
-                "auto_persist": self.config.auto_persist,
-                "index_dir": str(self.config.index_dir),
-                "index_files_exist": all(
-                    path.exists() for path in essential_paths.values()
-                ),
-                "last_modified": {},
-            }
-
-            # Get file modification times
-            for name, path in paths.items():
-                if path.exists():
-                    persistence_info["last_modified"][name] = path.stat().st_mtime
-
-            # Enhanced search components info
-            hybrid_search_info = {}
-            if self.hybrid_search:
-                hybrid_search_info = self.hybrid_search.get_stats()
-
-            # System performance metrics
-            cpu_percent = psutil.cpu_percent(interval=0.1)
-            memory_info = psutil.virtual_memory()
-            disk_usage = psutil.disk_usage("/")
-
-            performance_info = {
-                "cpu_usage_percent": cpu_percent,
-                "memory_usage_mb": memory_mb,
-                "memory_total_mb": memory_info.total / (1024 * 1024),
-                "memory_available_mb": memory_info.available / (1024 * 1024),
-                "memory_usage_percent": memory_info.percent,
-                "disk_usage_percent": disk_usage.percent,
-                "disk_free_gb": disk_usage.free / (1024 * 1024 * 1024),
-            }
-
-            return {
-                "status": "healthy",
-                "index_stats": index_stats,
-                "metadata": metadata_stats,
-                "relationships": relationship_stats,
-                "vector_store": vector_stats,
-                "embedding": embedding_info,
-                "hybrid_search": hybrid_search_info,
-                "performance": performance_info,
-                "persistence": persistence_info,
-                "configuration": self.config.get_config_summary(),
-            }
-
-        except Exception as e:
-            # Return error status with basic structure to prevent KeyErrors
-            return {
-                "status": "error",
-                "error": str(e),
-                "metadata": {},
-                "relationships": {},
-                "vector_store": {},
-                "embedding": {
-                    "provider": getattr(self.config, "embedding_provider", "unknown"),
-                    "model": getattr(self.config, "embedding_model", "unknown"),
-                    "dimension": None,
-                    "is_available": False,
-                },
-                "hybrid_search": {},
-                "performance": {},
-                "persistence": {},
-                "configuration": {},
-            }
+        """Get comprehensive system status."""
+        return self._system_status_service.get_status()
 
     def clear_index(self, remove_files: bool = False) -> Dict[str, Any]:
-        """Clear all indexed data.
-
-        Args:
-            remove_files: Whether to remove saved files
-
-        Returns:
-            Operation result
-        """
+        """Clear all indexed data."""
         try:
-            # Clear in-memory data
             self.metadata_store.clear()
-            if self.vector_store is not None:
-                self.vector_store.clear()
+            self._embedding_service.clear_vector_store()
 
-            # Remove files if requested
+            removed_files: list[str] = []
             if remove_files:
-                paths = self.config.get_index_paths()
-                for path in paths.values():
-                    if path.exists():
-                        path.unlink()
-                        logger.info(f"Removed {path}")
+                removed_files = self._persistence_service.remove_index_files()
 
             logger.info("Cleared index data")
             return {"success": True, "files_removed": remove_files}
-
-        except Exception as e:
-            error_msg = f"Failed to clear index: {str(e)}"
+        except Exception as exc:  # pragma: no cover - defensive guard
+            error_msg = f"Failed to clear index: {exc}"
             logger.error(error_msg)
             return {"success": False, "error": error_msg}
 
     def save_index(self) -> Dict[str, Any]:
-        """Manually save index to disk.
-
-        Returns:
-            Save operation result
-        """
+        """Manually save index to disk."""
         try:
-            self._auto_save()
+            self._persistence_service.auto_save(self.metadata_store)
             return {"success": True}
-        except Exception as e:
-            error_msg = f"Failed to save index: {str(e)}"
+        except Exception as exc:  # pragma: no cover - defensive guard
+            error_msg = f"Failed to save index: {exc}"
             logger.error(error_msg)
             return {"success": False, "error": error_msg}
 
-    def __enter__(self):
-        """Context manager entry."""
+    # ------------------------------------------------------------------
+    # Context manager support
+    # ------------------------------------------------------------------
+    def __enter__(self) -> "IndexManager":
         return self
 
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        """Context manager exit with comprehensive cleanup sequence."""
-        import logging
-
-        logger = logging.getLogger(__name__)
-
-        # Auto-save if enabled and no critical errors
-        if hasattr(self, "config") and self.config.auto_persist and exc_type is None:
+    def __exit__(self, exc_type, exc_val, exc_tb) -> bool:
+        if self.config.auto_persist and exc_type is None:
             try:
                 logger.info("Auto-saving index during cleanup")
                 self.save_index()
-            except Exception as e:
-                logger.warning(f"Auto-save failed during cleanup: {e}")
+            except Exception as exc:  # pragma: no cover - defensive guard
+                logger.warning("Auto-save failed during cleanup: %s", exc)
 
-        # Clean up embedder resources
-        if hasattr(self, "embedder") and self.embedder is not None:
-            try:
-                logger.debug("Cleaning up embedder resources")
-                self.embedder.cleanup()
-            except Exception as e:
-                logger.warning(f"Embedder cleanup failed: {e}")
-
-        # Clean up vector store if needed
-        if hasattr(self, "vector_store") and self.vector_store is not None:
-            try:
-                # Vector store might have cleanup methods in the future
-                logger.debug("Vector store cleanup completed")
-            except Exception as e:
-                logger.warning(f"Vector store cleanup failed: {e}")
-
-        # Clear any cached data
-        if (
-            hasattr(self, "search_intelligence")
-            and self.search_intelligence is not None
-        ):
-            try:
-                # Save search intelligence data before cleanup
-                logger.debug("Finalizing search intelligence data")
-                # Don't raise exceptions during cleanup
-            except Exception as e:
-                logger.warning(f"Search intelligence cleanup failed: {e}")
-
-        logger.info("IndexManager cleanup completed")
-
-        # Return False to not suppress exceptions
+        self._embedding_service.cleanup()
         return False
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _augment_with_embedding_info(self, stats: Dict[str, Any]) -> Dict[str, Any]:
+        """Attach embedding provider/model details to indexing statistics."""
+        self._embedding_service.ensure_loaded()
+        embedder = self._embedding_service.embedder
+        stats.update(
+            {
+                "embedding_provider": embedder.get_provider_name(),
+                "embedding_model": embedder.get_model_name(),
+            }
+        )
+        return stats

--- a/pycontextify/indexer/services/__init__.py
+++ b/pycontextify/indexer/services/__init__.py
@@ -1,0 +1,17 @@
+"""Service layer for the indexing subsystem."""
+
+from .embedding import EmbeddingService
+from .bootstrap import BootstrapService
+from .indexing import IndexingService
+from .search import SearchService
+from .system import SystemStatusService
+from .persistence import PersistenceService
+
+__all__ = [
+    "EmbeddingService",
+    "BootstrapService",
+    "IndexingService",
+    "SearchService",
+    "SystemStatusService",
+    "PersistenceService",
+]

--- a/pycontextify/indexer/services/bootstrap.py
+++ b/pycontextify/indexer/services/bootstrap.py
@@ -1,0 +1,326 @@
+"""Bootstrap and loading logic for persisted indices."""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import os
+import shutil
+import tarfile
+import threading
+import time
+import zipfile
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import Dict, Optional
+from urllib.parse import unquote, urlparse
+from urllib.request import url2pathname
+
+import requests
+
+from ...storage.metadata import MetadataStore
+from ...storage.vector import VectorStore
+from ...orchestrator.config import Config
+from .embedding import EmbeddingService
+
+
+class BootstrapService:
+    """Coordinate loading and bootstrap of persisted index artefacts."""
+
+    def __init__(
+        self,
+        config: Config,
+        metadata_store: MetadataStore,
+        embedding_service: EmbeddingService,
+    ) -> None:
+        self._config = config
+        self._metadata_store = metadata_store
+        self._embedding_service = embedding_service
+        self._logger = logging.getLogger(__name__)
+
+        self._bootstrap_thread: Optional[threading.Thread] = None
+        self._bootstrap_lock = threading.Lock()
+        self._load_lock = threading.Lock()
+
+    def auto_load(self) -> None:
+        """Attempt to load existing index artefacts, scheduling bootstrap if needed."""
+        try:
+            paths = self._config.get_index_paths()
+            essential = {
+                key: value
+                for key, value in paths.items()
+                if key in {"metadata", "index"}
+            }
+            missing = {key: value for key, value in essential.items() if not value.exists()}
+
+            if missing and self._restore_from_backups(missing):
+                missing = {
+                    key: value
+                    for key, value in essential.items()
+                    if not value.exists()
+                }
+
+            if not missing:
+                self._load_existing_index(paths)
+                return
+
+            self._logger.info("No existing index found, starting fresh")
+            self._schedule_bootstrap(paths)
+        except Exception as exc:  # pragma: no cover - defensive logging
+            self._logger.warning("Failed to load existing index: %s", exc)
+
+    def _load_existing_index(self, paths: Dict[str, Path]) -> None:
+        """Load stored metadata and vector files into memory."""
+        with self._load_lock:
+            self._logger.info("Loading existing index...")
+            metadata_path = str(paths["metadata"])
+            self._metadata_store.load_from_file(metadata_path)
+
+            if self._metadata_store.get_stats().get("total_chunks", 0) == 0:
+                self._logger.info("No chunks in metadata, skipping vector loading")
+                return
+
+            embedding_info = self._metadata_store.get_embedding_info()
+            if embedding_info and embedding_info.get("models"):
+                first_model = embedding_info["models"][0]
+                if ":" in first_model:
+                    stored_provider, stored_model = first_model.split(":", 1)
+                    self._config.embedding_provider = stored_provider
+                    self._config.embedding_model = stored_model
+                    self._logger.info(
+                        "Loading with stored embedding settings: %s:%s",
+                        stored_provider,
+                        stored_model,
+                    )
+
+            self._embedding_service.ensure_loaded()
+            vector_path = str(paths["index"])
+            if self._embedding_service.vector_store is not None:
+                self._embedding_service.load_vector_store(vector_path)
+                self._logger.info(
+                    "Loaded %s vectors",
+                    self._embedding_service.vector_store.get_total_vectors(),
+                )
+            else:
+                self._logger.error("Vector store not initialized, cannot load vectors")
+
+            self._logger.info("Successfully loaded existing index")
+
+    def _restore_from_backups(self, missing_paths: Dict[str, Path]) -> bool:
+        """Restore missing artefacts from configured backups when available."""
+        restored = False
+        for path in missing_paths.values():
+            if VectorStore.restore_latest_backup(path):
+                restored = True
+        if restored:
+            self._logger.info("Restored one or more index artifacts from backups")
+        return restored
+
+    def _schedule_bootstrap(self, paths: Dict[str, Path]) -> None:
+        """Start asynchronous bootstrap download when configured."""
+        sources = self._config.get_bootstrap_sources()
+        if not sources:
+            self._logger.info("Bootstrap archive URL not configured; skipping bootstrap")
+            return
+
+        with self._bootstrap_lock:
+            if self._bootstrap_thread and self._bootstrap_thread.is_alive():
+                self._logger.debug("Bootstrap worker already running; skipping reschedule")
+                return
+
+            self._logger.info("Scheduling bootstrap download for missing index artifacts")
+            self._bootstrap_thread = threading.Thread(
+                target=self._bootstrap_index_from_archive,
+                args=(paths, sources),
+                name="pycontextify-index-bootstrap",
+                daemon=True,
+            )
+            self._bootstrap_thread.start()
+
+    def _bootstrap_index_from_archive(
+        self, paths: Dict[str, Path], sources: Dict[str, str]
+    ) -> None:
+        """Download, verify and extract bootstrap archives."""
+        archive_url = sources.get("archive")
+        checksum_url = sources.get("checksum")
+
+        if not archive_url or not checksum_url:
+            self._logger.warning("Bootstrap sources incomplete, skipping bootstrap")
+            return
+
+        try:
+            essential = {
+                key: value
+                for key, value in paths.items()
+                if key in {"metadata", "index"}
+            }
+            missing = {key: value for key, value in essential.items() if not value.exists()}
+
+            if not missing:
+                self._logger.info("Bootstrap skipped because index artifacts already exist")
+                return
+
+            if self._restore_from_backups(missing):
+                missing = {
+                    key: value
+                    for key, value in essential.items()
+                    if not value.exists()
+                }
+                if not missing:
+                    self._logger.info(
+                        "Bootstrap cancelled after restoring artifacts from backups"
+                    )
+                    self._load_existing_index(paths)
+                    return
+
+            with TemporaryDirectory(prefix="pycontextify-bootstrap-") as tmpdir:
+                temp_dir = Path(tmpdir)
+                archive_path = self._download_to_path(archive_url, temp_dir)
+                checksum_value = self._fetch_checksum(checksum_url)
+                self._verify_checksum(archive_path, checksum_value)
+
+                extract_dir = temp_dir / "extracted"
+                extract_dir.mkdir(parents=True, exist_ok=True)
+                self._extract_archive(archive_path, extract_dir)
+                self._move_bootstrap_artifacts(extract_dir, paths)
+
+            remaining = {key: value for key, value in essential.items() if not value.exists()}
+            if remaining:
+                self._logger.warning(
+                    "Bootstrap archive did not provide all required artifacts: %s",
+                    ", ".join(sorted(path.name for path in remaining.values())),
+                )
+                return
+
+            self._logger.info("Bootstrap archive applied successfully; loading index")
+            self._load_existing_index(paths)
+        except Exception as exc:  # pragma: no cover - defensive logging
+            self._logger.warning(
+                "Failed to bootstrap index from %s: %s", archive_url, exc
+            )
+
+    def _download_to_path(
+        self, url: str, destination_dir: Path, max_retries: int = 3
+    ) -> Path:
+        """Download or copy the given URL into destination_dir with retry logic."""
+        parsed = urlparse(url)
+        filename = Path(unquote(parsed.path or "")).name or "bootstrap_archive"
+        destination_dir.mkdir(parents=True, exist_ok=True)
+        target_path = destination_dir / filename
+
+        if parsed.scheme == "file":
+            local_path = url2pathname(parsed.path)
+            source_path = Path(local_path)
+            if not source_path.exists():
+                raise FileNotFoundError(f"Bootstrap archive file not found: {source_path}")
+            self._logger.info("Copying bootstrap archive from %s", source_path)
+            shutil.copy2(source_path, target_path)
+            return target_path
+
+        if parsed.scheme in ("http", "https"):
+            last_exception: Optional[Exception] = None
+            for attempt in range(1, max_retries + 1):
+                try:
+                    if attempt > 1:
+                        delay = 2 ** (attempt - 2)
+                        self._logger.info(
+                            "Retrying download after %ss delay (attempt %s/%s)",
+                            delay,
+                            attempt,
+                            max_retries,
+                        )
+                        time.sleep(delay)
+
+                    with requests.get(url, stream=True, timeout=30) as response:
+                        response.raise_for_status()
+                        with open(target_path, "wb") as handle:
+                            for chunk in response.iter_content(chunk_size=1024 * 1024):
+                                if chunk:
+                                    handle.write(chunk)
+                    return target_path
+                except Exception as exc:  # pragma: no cover - network errors
+                    last_exception = exc
+                    self._logger.warning("Download failed: %s", exc)
+            if last_exception:
+                raise last_exception
+            raise RuntimeError("Failed to download bootstrap archive")
+
+        raise ValueError(f"Unsupported URL scheme for bootstrap archive: {parsed.scheme}")
+
+    def _fetch_checksum(self, url: str) -> str:
+        """Fetch the checksum value from remote location."""
+        parsed = urlparse(url)
+        if parsed.scheme == "file":
+            local_path = url2pathname(parsed.path)
+            with open(local_path, "r", encoding="utf-8") as handle:
+                content = handle.read()
+        elif parsed.scheme in ("http", "https"):
+            response = requests.get(url, timeout=30)
+            response.raise_for_status()
+            content = response.text
+        else:
+            raise ValueError(f"Unsupported checksum URL scheme: {parsed.scheme}")
+
+        if not content.strip():
+            raise ValueError("Bootstrap checksum file is empty")
+
+        parts = content.strip().split()
+        if not parts:
+            raise ValueError("Bootstrap checksum file is empty")
+
+        checksum = parts[0].lower()
+        if len(checksum) != 64 or not all(c in "0123456789abcdef" for c in checksum):
+            raise ValueError(
+                "Invalid SHA256 checksum format: %s" % checksum[:20]
+            )
+
+        self._logger.info("Fetched checksum: %s...", checksum[:16])
+        return checksum
+
+    def _verify_checksum(self, archive_path: Path, expected_checksum: str) -> None:
+        """Verify archive SHA256 checksum."""
+        digest = hashlib.sha256()
+        with archive_path.open("rb") as handle:
+            for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+                digest.update(chunk)
+        actual = digest.hexdigest()
+        if actual.lower() != expected_checksum.lower():
+            raise ValueError(
+                f"Bootstrap archive checksum mismatch: expected {expected_checksum}, got {actual}"
+            )
+
+    def _extract_archive(self, archive_path: Path, destination: Path) -> None:
+        """Extract supported archive formats into destination directory."""
+        lower_name = archive_path.name.lower()
+        if lower_name.endswith(".zip"):
+            with zipfile.ZipFile(archive_path) as zip_ref:
+                zip_ref.extractall(destination)
+            return
+
+        if lower_name.endswith(".tar.gz") or lower_name.endswith(".tgz"):
+            with tarfile.open(archive_path, "r:gz") as tar_ref:
+                tar_ref.extractall(destination)
+            return
+
+        raise ValueError(f"Unsupported bootstrap archive format: {archive_path}")
+
+    def _move_bootstrap_artifacts(self, extract_dir: Path, paths: Dict[str, Path]) -> None:
+        """Move extracted files into their final locations if missing."""
+        for key in ["metadata", "index"]:
+            destination = paths[key]
+            if destination.exists():
+                continue
+
+            matches = list(extract_dir.rglob(destination.name))
+            if not matches:
+                self._logger.warning(
+                    "Bootstrap archive missing expected %s file %s",
+                    key,
+                    destination.name,
+                )
+                continue
+
+            source_path = matches[0]
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            os.replace(source_path, destination)
+            self._logger.info("Bootstrapped %s", destination.name)

--- a/pycontextify/indexer/services/embedding.py
+++ b/pycontextify/indexer/services/embedding.py
@@ -1,0 +1,136 @@
+"""Embedding and vector store lifecycle management."""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+from ...embedder import EmbedderFactory
+from ...orchestrator.config import Config
+from ...storage.metadata import MetadataStore
+from ...storage.vector import VectorStore
+
+
+class EmbeddingService:
+    """Coordinates lazy embedder and vector store initialization."""
+
+    def __init__(self, config: Config) -> None:
+        self._config = config
+        self._embedder = None
+        self._vector_store: Optional[VectorStore] = None
+        self._initialized = False
+        self._logger = logging.getLogger(__name__)
+
+    @property
+    def embedder(self):
+        """Return the active embedder, loading it on demand."""
+        self.ensure_loaded()
+        return self._embedder
+
+    @property
+    def vector_store(self) -> Optional[VectorStore]:
+        """Return the managed vector store instance if available."""
+        return self._vector_store
+
+    def ensure_loaded(self) -> None:
+        """Lazily load the embedder and initialise the vector store."""
+        if self._initialized:
+            return
+
+        embedding_config = self._config.get_embedding_config()
+        self._logger.info(
+            "Lazy loading embedder: %s with model %s",
+            embedding_config["provider"],
+            embedding_config["model"],
+        )
+
+        self._embedder = EmbedderFactory.create_embedder(
+            provider=embedding_config["provider"],
+            model_name=embedding_config["model"],
+            **{
+                key: value
+                for key, value in embedding_config.items()
+                if key not in {"provider", "model"}
+            },
+        )
+        self._initialized = True
+        self._initialize_vector_store()
+        self._logger.info(
+            "Successfully loaded embedder: %s",
+            self._embedder.get_provider_name(),
+        )
+
+    def _initialize_vector_store(self) -> None:
+        """Create the vector store once the embedder dimension is known."""
+        if self._embedder is None:
+            return
+        if self._vector_store is not None:
+            return
+
+        dimension = self._embedder.get_dimension()
+        self._vector_store = VectorStore(dimension, self._config)
+        self._logger.info("Initialized vector store with dimension %s", dimension)
+
+    def ensure_vector_store(self) -> VectorStore:
+        """Return an initialised vector store, creating it on demand."""
+        self.ensure_loaded()
+        self._initialize_vector_store()
+        if self._vector_store is None:
+            raise RuntimeError("Vector store could not be initialised")
+        return self._vector_store
+
+    def is_initialized(self) -> bool:
+        """Return True when the embedder has been initialised."""
+        return self._initialized
+
+    def get_loaded_embedder(self):
+        """Return the embedder if already initialised without triggering loads."""
+        if not self._initialized:
+            return None
+        return self._embedder
+
+    def is_vector_store_empty(self) -> bool:
+        """Return True if the vector store has no vectors."""
+        if self._vector_store is None:
+            return True
+        return self._vector_store.is_empty()
+
+    def validate_embedding(self, metadata_store: MetadataStore) -> bool:
+        """Validate compatibility between stored metadata and the embedder."""
+        if metadata_store.get_stats().get("total_chunks", 0) == 0:
+            return True
+
+        self.ensure_loaded()
+        if self._embedder is None:
+            return False
+        return metadata_store.validate_embedding_compatibility(
+            self._embedder.get_provider_name(),
+            self._embedder.get_model_name(),
+        )
+
+    def save_vector_store(self, path: str) -> None:
+        """Persist the vector store to disk when present."""
+        if self._vector_store is None:
+            return
+        self._vector_store.save_to_file(path)
+
+    def load_vector_store(self, path: str) -> None:
+        """Load vector store contents from disk, creating the store if needed."""
+        vector_store = self.ensure_vector_store()
+        vector_store.load_from_file(path)
+
+    def clear_vector_store(self) -> None:
+        """Remove all vectors from the managed store."""
+        if self._vector_store is not None:
+            self._vector_store.clear()
+
+    def cleanup(self) -> None:
+        """Release embedder resources and reset state."""
+        if self._embedder is not None:
+            try:
+                self._embedder.cleanup()
+            except Exception as exc:  # pragma: no cover - defensive cleanup
+                self._logger.warning("Embedder cleanup failed: %s", exc)
+        self._embedder = None
+        self._vector_store = None
+        self._initialized = False

--- a/pycontextify/indexer/services/indexing.py
+++ b/pycontextify/indexer/services/indexing.py
@@ -1,0 +1,165 @@
+"""Content ingestion workflows for the index."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict
+
+from ...chunker import ChunkerFactory
+from ...storage.metadata import MetadataStore, SourceType
+from ..loaders import LoaderFactory
+from .embedding import EmbeddingService
+from ...orchestrator.config import Config
+
+
+class IndexingService:
+    """Coordinate loaders, chunkers and embeddings for ingestion."""
+
+    def __init__(
+        self,
+        config: Config,
+        metadata_store: MetadataStore,
+        embedding_service: EmbeddingService,
+    ) -> None:
+        self._config = config
+        self._metadata_store = metadata_store
+        self._embedding_service = embedding_service
+        self._logger = logging.getLogger(__name__)
+
+    def index_codebase(self, path: str) -> Dict[str, Any]:
+        """Index a source tree of code files."""
+        self._logger.info("Starting codebase indexing: %s", path)
+        try:
+            loader = LoaderFactory.get_loader(
+                SourceType.CODE, max_file_size_mb=self._config.max_file_size_mb
+            )
+            files = loader.load(path)
+            if not files:
+                return {"error": "No files found to index"}
+
+            chunks_added = 0
+            for file_path, content in files:
+                chunks_added += self._process_content(content, file_path, SourceType.CODE)
+
+            return {
+                "files_processed": len(files),
+                "chunks_added": chunks_added,
+                "source_type": "code",
+            }
+        except Exception as exc:
+            error_msg = f"Failed to index codebase {path}: {exc}"
+            self._logger.error(error_msg)
+            return {"error": error_msg}
+
+    def index_document(self, path: str) -> Dict[str, Any]:
+        """Index a single document file."""
+        self._logger.info("Starting document indexing: %s", path)
+        try:
+            loader = LoaderFactory.get_loader(
+                SourceType.DOCUMENT, pdf_engine=self._config.pdf_engine
+            )
+            files = loader.load(path)
+            if not files:
+                return {"error": "Could not load document"}
+
+            file_path, content = files[0]
+            chunks_added = self._process_content(
+                content, file_path, SourceType.DOCUMENT
+            )
+            return {
+                "file_processed": file_path,
+                "chunks_added": chunks_added,
+                "source_type": "document",
+            }
+        except Exception as exc:
+            error_msg = f"Failed to index document {path}: {exc}"
+            self._logger.error(error_msg)
+            return {"error": error_msg}
+
+    def index_webpage(
+        self, url: str, recursive: bool = False, max_depth: int = 1
+    ) -> Dict[str, Any]:
+        """Index the content of a web page or crawl."""
+        self._logger.info(
+            "Starting webpage indexing: %s (recursive=%s, max_depth=%s)",
+            url,
+            recursive,
+            max_depth,
+        )
+        try:
+            loader = LoaderFactory.get_loader(
+                SourceType.WEBPAGE, delay_seconds=self._config.crawl_delay_seconds
+            )
+            pages = loader.load(url, recursive=recursive, max_depth=max_depth)
+            if not pages:
+                return {"error": "Could not load any web pages"}
+
+            chunks_added = 0
+            for page_url, content in pages:
+                chunks_added += self._process_content(
+                    content, page_url, SourceType.WEBPAGE
+                )
+
+            return {
+                "pages_processed": len(pages),
+                "chunks_added": chunks_added,
+                "source_type": "webpage",
+                "recursive": recursive,
+                "max_depth": max_depth,
+            }
+        except Exception as exc:
+            error_msg = f"Failed to index webpage {url}: {exc}"
+            self._logger.error(error_msg)
+            return {"error": error_msg}
+
+    def _process_content(
+        self, content: str, source_path: str, source_type: SourceType
+    ) -> int:
+        """Chunk and embed the provided content."""
+        existing_chunks = self._metadata_store.get_chunks_by_source_path(source_path)
+        if existing_chunks:
+            self._logger.info(
+                "Found %s existing chunks for %s, removing for re-indexing",
+                len(existing_chunks),
+                source_path,
+            )
+            vector_store = self._embedding_service.vector_store
+            if vector_store is not None:
+                faiss_ids_to_remove = []
+                for chunk in existing_chunks:
+                    faiss_id = self._metadata_store.get_faiss_id(chunk.chunk_id)
+                    if faiss_id is not None:
+                        faiss_ids_to_remove.append(faiss_id)
+                if faiss_ids_to_remove:
+                    vector_store.remove_vectors(faiss_ids_to_remove)
+
+            for chunk in existing_chunks:
+                faiss_id = self._metadata_store.get_faiss_id(chunk.chunk_id)
+                if faiss_id is not None:
+                    self._metadata_store.remove_chunk(faiss_id)
+            self._logger.info(
+                "Removed %s existing chunks for re-indexing", len(existing_chunks)
+            )
+
+        chunker = ChunkerFactory.get_chunker(source_type, self._config)
+        self._embedding_service.ensure_loaded()
+        embedder = self._embedding_service.embedder
+
+        chunks = chunker.chunk_text(
+            content,
+            source_path,
+            embedder.get_provider_name(),
+            embedder.get_model_name(),
+        )
+        if not chunks:
+            return 0
+
+        texts = [chunk.chunk_text for chunk in chunks]
+        embeddings = embedder.embed_texts(texts)
+        vector_store = self._embedding_service.ensure_vector_store()
+        faiss_ids = vector_store.add_vectors(embeddings)
+
+        for chunk, faiss_id in zip(chunks, faiss_ids):
+            self._metadata_store.add_chunk(chunk)
+
+        return len(chunks)

--- a/pycontextify/indexer/services/persistence.py
+++ b/pycontextify/indexer/services/persistence.py
@@ -1,0 +1,44 @@
+"""Persistence utilities for index artefacts."""
+
+from __future__ import annotations
+
+import logging
+from typing import List
+
+from ...orchestrator.config import Config
+from ...storage.metadata import MetadataStore
+from .embedding import EmbeddingService
+
+
+class PersistenceService:
+    """Handle persistence concerns such as auto-saving and cleanup."""
+
+    def __init__(self, config: Config, embedding_service: EmbeddingService) -> None:
+        self._config = config
+        self._embedding_service = embedding_service
+        self._logger = logging.getLogger(__name__)
+
+    def auto_save(self, metadata_store: MetadataStore) -> None:
+        """Persist metadata and vector store when auto-persist is enabled."""
+        if not self._config.auto_persist:
+            return
+
+        self._config.ensure_index_directory()
+        paths = self._config.get_index_paths()
+
+        index_path = str(paths["index"])
+        metadata_path = str(paths["metadata"])
+
+        self._embedding_service.save_vector_store(index_path)
+        metadata_store.save_to_file(metadata_path, self._config.compress_metadata)
+        self._logger.info("Auto-saved index to disk")
+
+    def remove_index_files(self) -> List[str]:
+        """Delete persisted index artefacts and return the removed paths."""
+        removed: List[str] = []
+        for path in self._config.get_index_paths().values():
+            if path.exists():
+                path.unlink()
+                removed.append(str(path))
+                self._logger.info("Removed %s", path)
+        return removed

--- a/pycontextify/indexer/services/search.py
+++ b/pycontextify/indexer/services/search.py
@@ -1,0 +1,360 @@
+"""Search coordination across vector and hybrid engines."""
+
+from __future__ import annotations
+
+import logging
+import time
+from pathlib import Path
+from typing import Any, Dict, List
+
+from ...storage.metadata import MetadataStore, SourceType
+from ...orchestrator.config import Config
+from ...search.models import (
+    SearchErrorCode,
+    SearchPerformanceLogger,
+    SearchResponse,
+    SearchResult,
+    create_search_performance_info,
+    create_search_provenance,
+    create_structured_metadata,
+    create_structured_scores,
+    enhance_search_results_with_ranking,
+)
+from ..pdf_loader import PDFLoader
+from .embedding import EmbeddingService
+
+
+class SearchService:
+    """Encapsulate all search related behaviours."""
+
+    def __init__(
+        self,
+        config: Config,
+        metadata_store: MetadataStore,
+        embedding_service: EmbeddingService,
+    ) -> None:
+        self._config = config
+        self._metadata_store = metadata_store
+        self._embedding_service = embedding_service
+        self._logger = logging.getLogger(__name__)
+        self._performance_logger = SearchPerformanceLogger()
+        self._hybrid_search = None
+        self._initialize_hybrid_search()
+
+    @property
+    def performance_logger(self) -> SearchPerformanceLogger:
+        """Expose the performance logger for reporting."""
+        return self._performance_logger
+
+    def search(
+        self, query: str, top_k: int = 5, display_format: str = "readable"
+    ) -> SearchResponse:
+        """Perform semantic search with optional hybrid enhancement."""
+        start_time = time.time()
+        try:
+            vector_store = self._embedding_service.vector_store
+            if vector_store is None or vector_store.is_empty():
+                return SearchResponse.create_error(
+                    query=query,
+                    error="No indexed content available. Please index some documents, code, or webpages first.",
+                    error_code=SearchErrorCode.NO_CONTENT.value,
+                    search_config=self._get_search_config(),
+                    recovery_suggestions=[
+                        "Use index_document(), index_codebase(), or index_webpage() to add content",
+                        "Check if auto_load is enabled and index files exist",
+                        "Verify the vector store was initialized properly",
+                    ],
+                )
+
+            self._embedding_service.ensure_loaded()
+            embedder = self._embedding_service.embedder
+            query_embedding = embedder.embed_single(query)
+
+            distances, indices = vector_store.search(query_embedding, top_k * 2)
+            search_results = self._create_vector_search_results(distances, indices)
+
+            if self._config.use_hybrid_search and self._hybrid_search:
+                try:
+                    self._ensure_hybrid_search_index()
+                    hybrid_results = self._hybrid_search.search(query, top_k * 2)
+                    combined = self._combine_hybrid_results(search_results, hybrid_results)
+                    search_results = combined[:top_k]
+                except Exception as exc:
+                    self._logger.warning("Hybrid search failed, using vector-only: %s", exc)
+                    search_results = search_results[:top_k]
+            else:
+                search_results = search_results[:top_k]
+
+            enhanced_results = enhance_search_results_with_ranking(
+                results=search_results,
+                query=query,
+                include_explanations=True,
+                include_confidence=True,
+            )
+            performance = create_search_performance_info(
+                start_time=start_time,
+                search_mode="hybrid" if self._config.use_hybrid_search else "vector",
+                total_candidates=len(search_results),
+            )
+
+            response = SearchResponse.create_success(
+                query=query,
+                results=enhanced_results,
+                search_config=self._get_search_config(),
+                performance=performance,
+            )
+            response.display_format = display_format
+            if display_format != "structured":
+                response.formatted_output = response.format_for_display(display_format)
+
+            self._performance_logger.log_search_performance(response)
+            return response
+        except Exception as exc:
+            self._logger.error("Search failed: %s", exc)
+            return SearchResponse.create_error(
+                query=query,
+                error=f"Search operation failed: {exc}",
+                error_code=SearchErrorCode.SEARCH_ERROR.value,
+                search_config=self._get_search_config(),
+                recovery_suggestions=[
+                    "Check if the index is properly loaded",
+                    "Verify the embedder is available and functional",
+                    "Try a simpler query if the current one is complex",
+                ],
+            )
+
+    def get_performance_summary(self) -> Dict[str, Any]:
+        """Return aggregated performance statistics."""
+        return self._performance_logger.get_performance_summary()
+
+    def get_hybrid_stats(self) -> Dict[str, Any]:
+        """Expose hybrid search statistics for monitoring."""
+        if self._hybrid_search:
+            return self._hybrid_search.get_stats()
+        return {}
+
+    def get_hybrid_engine(self):
+        """Return the underlying hybrid engine for compatibility."""
+        return self._hybrid_search
+
+    def _initialize_hybrid_search(self) -> None:
+        """Initialize hybrid search engine if enabled."""
+        if not self._config.use_hybrid_search:
+            self._logger.info("Hybrid search disabled by configuration")
+            return
+        try:
+            from ...search.hybrid import HybridSearchEngine
+
+            self._hybrid_search = HybridSearchEngine(
+                keyword_weight=self._config.keyword_weight
+            )
+            self._logger.info(
+                "Initialized hybrid search with keyword weight: %s",
+                self._config.keyword_weight,
+            )
+        except ImportError as exc:
+            self._logger.warning("Could not initialize hybrid search: %s", exc)
+            self._hybrid_search = None
+
+    def _ensure_hybrid_search_index(self) -> None:
+        """Ensure hybrid search index is built from current chunks."""
+        if not self._hybrid_search:
+            return
+        current_chunk_count = self._metadata_store.get_stats()["total_chunks"]
+        hybrid_stats = self._hybrid_search.get_stats()
+        if hybrid_stats["indexed_documents"] == current_chunk_count:
+            return
+
+        self._logger.info("Building hybrid search index...")
+        all_chunks = self._metadata_store.get_all_chunks()
+        if not all_chunks:
+            return
+
+        chunk_ids = [chunk.chunk_id for chunk in all_chunks]
+        texts = [chunk.chunk_text for chunk in all_chunks]
+        self._hybrid_search.add_documents(chunk_ids, texts)
+        self._logger.info(
+            "Built hybrid search index with %s documents", len(texts)
+        )
+
+    def _get_search_config(self) -> Dict[str, Any]:
+        """Summarise search configuration for responses."""
+        return {
+            "hybrid_search": self._config.use_hybrid_search,
+            "embedding_provider": self._config.embedding_provider,
+            "embedding_model": self._config.embedding_model,
+            "keyword_weight": getattr(self._config, "keyword_weight", 0.3),
+        }
+
+    def _create_vector_search_results(self, distances, indices) -> List[SearchResult]:
+        """Convert raw vector search results into SearchResult objects."""
+        results: List[SearchResult] = []
+        for distance, idx in zip(distances, indices):
+            if idx < 0:
+                continue
+            chunk = self._metadata_store.get_chunk(idx)
+            if not chunk:
+                continue
+
+            source_info = self._create_source_info_from_chunk(chunk)
+            relevance_score = max(0.0, 1.0 - distance)
+            metadata = (
+                create_structured_metadata(**chunk.metadata)
+                if getattr(chunk, "metadata", None)
+                else None
+            )
+            result = SearchResult(
+                chunk_id=chunk.chunk_id,
+                source_path=chunk.source_path,
+                source_type=chunk.source_type.value
+                if isinstance(chunk.source_type, SourceType)
+                else chunk.source_type,
+                text=chunk.chunk_text,
+                relevance_score=relevance_score,
+                scores=create_structured_scores(
+                    vector_score=relevance_score,
+                    original_score=relevance_score,
+                ),
+                metadata=metadata,
+                provenance=create_search_provenance(
+                    search_features=["vector_search"],
+                    search_stage="vector_only",
+                ),
+                source_info=source_info,
+            )
+            results.append(result)
+        return results
+
+    def _combine_hybrid_results(self, vector_results, hybrid_results):
+        """Combine vector and keyword scores."""
+        combined = {result.chunk_id: {
+            "result": result,
+            "vector_score": result.relevance_score,
+            "hybrid_score": 0.0,
+        } for result in vector_results}
+
+        for hybrid in hybrid_results:
+            chunk_id = hybrid.get("chunk_id")
+            if chunk_id in combined:
+                combined[chunk_id]["hybrid_score"] = hybrid.get("score", 0.0)
+            else:
+                metadata = self._metadata_store.get_chunk_by_chunk_id(chunk_id)
+                if not metadata:
+                    continue
+                vector_result = SearchResult(
+                    chunk_id=metadata.chunk_id,
+                    source_path=metadata.source_path,
+                    source_type=metadata.source_type.value
+                    if isinstance(metadata.source_type, SourceType)
+                    else metadata.source_type,
+                    text=metadata.chunk_text,
+                    relevance_score=hybrid.get("score", 0.0),
+                    scores=create_structured_scores(
+                        vector_score=0.0,
+                        original_score=hybrid.get("score", 0.0),
+                    ),
+                    metadata=(
+                        create_structured_metadata(**metadata.metadata)
+                        if getattr(metadata, "metadata", None)
+                        else None
+                    ),
+                    provenance=create_search_provenance(
+                        search_features=["hybrid_search"],
+                        search_stage="hybrid_only",
+                    ),
+                    source_info=self._create_source_info_from_chunk(metadata),
+                )
+                combined[chunk_id] = {
+                    "result": vector_result,
+                    "vector_score": 0.0,
+                    "hybrid_score": hybrid.get("score", 0.0),
+                }
+
+        final_results = []
+        for values in combined.values():
+            result = values["result"]
+            vector_score = values["vector_score"]
+            hybrid_score = values["hybrid_score"]
+            combined_score = (vector_score * 0.7) + (hybrid_score * 0.3)
+            result.relevance_score = combined_score
+            result.scores = create_structured_scores(
+                vector_score=vector_score,
+                hybrid_score=hybrid_score,
+                original_score=combined_score,
+            )
+            result.provenance = create_search_provenance(
+                search_features=["vector_search", "hybrid_search"],
+                search_stage="combined",
+            )
+            final_results.append(result)
+        final_results.sort(key=lambda item: item.relevance_score, reverse=True)
+        return final_results
+
+    def _create_source_info_from_chunk(self, chunk) -> Dict[str, Any]:
+        """Extract structured source information from a chunk."""
+        source_path = getattr(chunk, "source_path", "/unknown")
+        source_type_val = getattr(chunk, "source_type", None)
+        source_type_str = (
+            source_type_val.value
+            if hasattr(source_type_val, "value")
+            else str(source_type_val) if source_type_val else "unknown"
+        )
+        source_info: Dict[str, Any] = {
+            "file_path": str(source_path) if source_path else "/unknown",
+            "source_type": source_type_str,
+        }
+
+        if isinstance(source_path, str) and source_path != "/unknown":
+            try:
+                path_obj = Path(source_path)
+                if path_obj.exists() and path_obj.is_file():
+                    stat = path_obj.stat()
+                    source_info.update(
+                        {
+                            "filename": path_obj.name,
+                            "file_extension": path_obj.suffix.lower(),
+                            "file_size_bytes": stat.st_size,
+                            "file_size_mb": round(stat.st_size / (1024 * 1024), 2),
+                            "created_at": stat.st_ctime,
+                            "modified_at": stat.st_mtime,
+                        }
+                    )
+                else:
+                    source_info["filename"] = path_obj.name
+                    source_info["file_extension"] = path_obj.suffix.lower()
+            except (OSError, ValueError, TypeError):
+                self._logger.debug("Could not extract file metadata for %s", source_path)
+                source_info["filename"] = "unknown"
+                if isinstance(source_path, str) and source_path.startswith(("http://", "https://")):
+                    source_info["source_type"] = "webpage"
+
+            if source_type_str == "document" and source_path.lower().endswith(".pdf"):
+                try:
+                    pdf_loader = PDFLoader()
+                    pdf_metadata = pdf_loader.get_pdf_info(source_path)
+                    source_info.update(pdf_metadata)
+                except Exception as exc:
+                    self._logger.debug("Could not extract PDF metadata: %s", exc)
+
+        chunk_text = getattr(chunk, "chunk_text", "")
+        if chunk_text and isinstance(chunk_text, str):
+            try:
+                pdf_loader = PDFLoader()
+                page_info = pdf_loader.extract_page_context(chunk_text)
+                if page_info:
+                    source_info.update(page_info)
+            except Exception as exc:
+                self._logger.debug("Could not extract page context: %s", exc)
+
+        if hasattr(chunk, "parent_section"):
+            parent_section = getattr(chunk, "parent_section", None)
+            if parent_section:
+                source_info["section_title"] = str(parent_section)
+
+        if hasattr(chunk, "metadata"):
+            metadata = getattr(chunk, "metadata", None)
+            if metadata and hasattr(metadata, "items"):
+                for key, value in metadata.items():
+                    if key not in source_info and value is not None:
+                        source_info[key] = value
+        return source_info

--- a/pycontextify/indexer/services/system.py
+++ b/pycontextify/indexer/services/system.py
@@ -1,0 +1,126 @@
+"""System and health status reporting."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict
+
+import psutil
+
+from ...orchestrator.config import Config
+from ...storage.metadata import MetadataStore
+from .embedding import EmbeddingService
+from .search import SearchService
+
+
+class SystemStatusService:
+    """Aggregate runtime information for monitoring."""
+
+    def __init__(
+        self,
+        config: Config,
+        metadata_store: MetadataStore,
+        embedding_service: EmbeddingService,
+        search_service: SearchService,
+    ) -> None:
+        self._config = config
+        self._metadata_store = metadata_store
+        self._embedding_service = embedding_service
+        self._search_service = search_service
+        self._logger = logging.getLogger(__name__)
+
+    def get_status(self) -> Dict[str, Any]:
+        """Return a structured snapshot of the system state."""
+        try:
+            metadata_stats = self._metadata_store.get_stats()
+            vector_store = self._embedding_service.vector_store
+            vector_stats = (
+                vector_store.get_index_info() if vector_store else {"total_vectors": 0, "dimension": None}
+            )
+
+            index_stats = {
+                "total_chunks": metadata_stats.get("total_chunks", 0),
+                "total_documents": len(
+                    {chunk.source_path for chunk in self._metadata_store.get_all_chunks()}
+                ),
+                "total_vectors": vector_stats.get("total_vectors", 0),
+                "source_types": metadata_stats.get("source_types", {}),
+            }
+
+            process = psutil.Process()
+            memory_mb = process.memory_info().rss / (1024 * 1024)
+
+            embedder = self._embedding_service.get_loaded_embedder()
+            if not embedder:
+                embedding_info = {
+                    "provider": self._config.embedding_provider,
+                    "model": self._config.embedding_model,
+                    "dimension": None,
+                    "is_available": False,
+                }
+            else:
+                embedding_info = {
+                    "provider": embedder.get_provider_name(),
+                    "model": embedder.get_model_name(),
+                    "dimension": embedder.get_dimension(),
+                    "is_available": embedder.is_available(),
+                }
+
+            paths = self._config.get_index_paths()
+            essential_paths = {k: v for k, v in paths.items() if k in {"metadata", "index"}}
+            persistence_info = {
+                "auto_persist": self._config.auto_persist,
+                "index_dir": str(self._config.index_dir),
+                "index_files_exist": all(path.exists() for path in essential_paths.values()),
+                "last_modified": {},
+            }
+            for name, path in paths.items():
+                if path.exists():
+                    persistence_info["last_modified"][name] = path.stat().st_mtime
+
+            hybrid_info = self._search_service.get_hybrid_stats()
+
+            cpu_percent = psutil.cpu_percent(interval=0.1)
+            memory_info = psutil.virtual_memory()
+            disk_usage = psutil.disk_usage("/")
+            performance = {
+                "cpu_usage_percent": cpu_percent,
+                "memory_usage_mb": memory_mb,
+                "memory_total_mb": memory_info.total / (1024 * 1024),
+                "memory_available_mb": memory_info.available / (1024 * 1024),
+                "memory_usage_percent": memory_info.percent,
+                "disk_usage_percent": disk_usage.percent,
+                "disk_free_gb": disk_usage.free / (1024 * 1024 * 1024),
+            }
+
+            return {
+                "status": "healthy",
+                "index_stats": index_stats,
+                "metadata": metadata_stats,
+                "relationships": {},
+                "vector_store": vector_stats,
+                "embedding": embedding_info,
+                "hybrid_search": hybrid_info,
+                "performance": performance,
+                "persistence": persistence_info,
+                "configuration": self._config.get_config_summary(),
+            }
+        except Exception as exc:  # pragma: no cover - defensive path
+            self._logger.error("Failed to gather system status: %s", exc)
+            return {
+                "status": "error",
+                "error": str(exc),
+                "metadata": {},
+                "relationships": {},
+                "vector_store": {},
+                "embedding": {
+                    "provider": getattr(self._config, "embedding_provider", "unknown"),
+                    "model": getattr(self._config, "embedding_model", "unknown"),
+                    "dimension": None,
+                    "is_available": False,
+                },
+                "hybrid_search": {},
+                "performance": {},
+                "persistence": {},
+                "configuration": {},
+            }

--- a/tests/unit/test_services.py
+++ b/tests/unit/test_services.py
@@ -1,0 +1,150 @@
+"""Unit tests for the refactored indexing services."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict
+
+import numpy as np
+import pytest
+
+from pycontextify.indexer.services.embedding import EmbeddingService
+from pycontextify.indexer.services.persistence import PersistenceService
+from pycontextify.storage.metadata import ChunkMetadata, MetadataStore, SourceType
+
+
+class DummyEmbedder:
+    """Simple stand-in for an embedding backend used in service tests."""
+
+    def __init__(self, dimension: int = 4) -> None:
+        self._dimension = dimension
+        self._cleaned = False
+
+    def get_provider_name(self) -> str:  # pragma: no cover - trivial
+        return "dummy"
+
+    def get_model_name(self) -> str:  # pragma: no cover - trivial
+        return "dummy-model"
+
+    def get_dimension(self) -> int:
+        return self._dimension
+
+    def embed_texts(self, texts):  # pragma: no cover - not used in tests
+        return np.zeros((len(texts), self._dimension), dtype=np.float32)
+
+    def embed_single(self, text):  # pragma: no cover - not used in tests
+        return np.zeros(self._dimension, dtype=np.float32)
+
+    def is_available(self) -> bool:  # pragma: no cover - trivial
+        return True
+
+    def cleanup(self) -> None:
+        self._cleaned = True
+
+
+class DummyVectorStore:
+    """Minimal vector store spy capturing persistence calls."""
+
+    def __init__(self, dimension: int, config) -> None:  # pragma: no cover - simple init
+        self.dimension = dimension
+        self.config = config
+        self.saved_path: str | None = None
+
+    def save_to_file(self, path: str) -> None:
+        self.saved_path = path
+
+    def clear(self) -> None:  # pragma: no cover - not used
+        pass
+
+    def is_empty(self) -> bool:  # pragma: no cover - not used
+        return False
+
+    def get_index_info(self) -> Dict[str, int]:  # pragma: no cover - not used
+        return {"total_vectors": 0, "dimension": self.dimension}
+
+
+class DummyConfig:
+    """Lightweight configuration stub for service testing."""
+
+    def __init__(self, base_dir: Path) -> None:
+        self.auto_persist = True
+        self.compress_metadata = False
+        self.index_dir = base_dir
+        self.index_name = "test_index"
+        self.embedding_provider = "dummy"
+        self.embedding_model = "dummy-model"
+
+    def get_embedding_config(self) -> Dict[str, str]:
+        return {"provider": self.embedding_provider, "model": self.embedding_model}
+
+    def ensure_index_directory(self) -> None:
+        self.index_dir.mkdir(parents=True, exist_ok=True)
+
+    def get_index_paths(self) -> Dict[str, Path]:
+        base_path = self.index_dir / self.index_name
+        return {
+            "index": base_path.with_suffix(".faiss"),
+            "metadata": base_path.with_suffix(".pkl"),
+            "relationships": base_path.with_name(f"{base_path.name}_relationships.pkl"),
+        }
+
+    def get_config_summary(self) -> Dict[str, str]:  # pragma: no cover - diagnostic
+        return {}
+
+
+@pytest.fixture()
+def dummy_config(tmp_path: Path) -> DummyConfig:
+    return DummyConfig(tmp_path)
+
+
+def test_embedding_service_lazy_initialisation(monkeypatch, dummy_config):
+    """Embedder and vector store should only initialise on demand."""
+
+    created = {}
+
+    def fake_create_embedder(*_, **__):
+        created["called"] = True
+        return DummyEmbedder()
+
+    monkeypatch.setattr(
+        "pycontextify.indexer.services.embedding.EmbedderFactory.create_embedder",
+        fake_create_embedder,
+    )
+    monkeypatch.setattr(
+        "pycontextify.indexer.services.embedding.VectorStore",
+        DummyVectorStore,
+    )
+
+    service = EmbeddingService(dummy_config)
+
+    assert not service.is_initialized()
+    service.ensure_loaded()
+
+    assert service.is_initialized()
+    assert created["called"] is True
+    assert isinstance(service.embedder, DummyEmbedder)
+    assert isinstance(service.vector_store, DummyVectorStore)
+
+
+def test_persistence_service_auto_save_creates_files(tmp_path: Path):
+    """Auto-save should persist metadata and vector store artefacts."""
+
+    config = DummyConfig(tmp_path)
+    embedding_service = EmbeddingService(config)
+    embedding_service._vector_store = DummyVectorStore(4, config)
+
+    metadata_store = MetadataStore()
+    metadata_store.add_chunk(
+        ChunkMetadata(
+            source_path="demo.txt",
+            source_type=SourceType.DOCUMENT,
+            chunk_text="demo",
+        )
+    )
+
+    persistence = PersistenceService(config, embedding_service)
+    persistence.auto_save(metadata_store)
+
+    paths = config.get_index_paths()
+    assert paths["metadata"].exists()
+    assert embedding_service.vector_store.saved_path == str(paths["index"])


### PR DESCRIPTION
## Summary
- refactor `IndexManager` into a thin facade that composes dedicated embedding, persistence, indexing, search, and status services
- add service modules that encapsulate embedding lifecycle, bootstrap loading, ingestion workflows, and hybrid search coordination
- extend the unit test suite with service-specific tests covering lazy initialisation and persistence behaviour

## Testing
- pytest tests/unit -q
- pytest tests/unit


------
https://chatgpt.com/codex/tasks/task_e_68e560202a38833294f03bb63423cd19