### PR TITLE
Consolidate orchestrator into indexer module

### DIFF
--- a/pycontextify/__init__.py
+++ b/pycontextify/__init__.py
@@ -2,7 +2,7 @@
 
 from importlib import metadata as _metadata
 
-from .orchestrator_config import Config
+from .indexer import Config
 from .indexer_manager import IndexManager
 from . import mcp_server as mcp_server
 

--- a/pycontextify/indexer.py
+++ b/pycontextify/indexer.py
@@ -1,7 +1,12 @@
-"""Indexing runtime for PyContextify."""
+"""Indexing runtime for PyContextify.
+
+This module now serves as the single entry point for index related
+configuration and orchestration utilities.
+"""
 
 from .indexer_loaders import LoaderFactory
 from .indexer_manager import IndexManager
 from .indexer_pdf_loader import PDFLoader
+from .orchestrator_config import Config
 
-__all__ = ["IndexManager", "LoaderFactory", "PDFLoader"]
+__all__ = ["IndexManager", "LoaderFactory", "PDFLoader", "Config"]

--- a/pycontextify/orchestrator.py
+++ b/pycontextify/orchestrator.py
@@ -1,5 +1,0 @@
-"""Orchestration utilities for PyContextify."""
-
-from .orchestrator_config import Config
-
-__all__ = ["Config"]


### PR DESCRIPTION
## Summary
- fold the orchestrator exports into the indexer module so it exposes `Config`
- route the package `Config` import through `pycontextify.indexer` and remove the redundant `orchestrator` module

## Testing
- pytest tests/unit -q

------
https://chatgpt.com/codex/tasks/task_e_68e5f1d7c7588332ae1ef924cc5dc196